### PR TITLE
JUnit @Rule for Casandra Unit

### DIFF
--- a/src/main/java/org/cassandraunit/AbstractCassandraUnit4TestCase.java
+++ b/src/main/java/org/cassandraunit/AbstractCassandraUnit4TestCase.java
@@ -2,7 +2,6 @@ package org.cassandraunit;
 
 import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.Keyspace;
-import me.prettyprint.hector.api.factory.HFactory;
 
 import org.cassandraunit.dataset.DataSet;
 import org.junit.Before;
@@ -22,15 +21,11 @@ public abstract class AbstractCassandraUnit4TestCase {
 	@Before
 	public void before() throws Exception {
 		if (!initialized) {
-			cassandraUnit = new CassandraUnit();
+			cassandraUnit = new CassandraUnit(getDataSet());
 			cassandraUnit.before();
 
-			/* create structure and load data */
-			DataLoader dataLoader = new DataLoader(cassandraUnit.clusterName, cassandraUnit.host);
-			dataLoader.load(getDataSet());
-
 			cluster = cassandraUnit.cluster;
-			keyspace = HFactory.createKeyspace(getDataSet().getKeyspace().getName(), getCluster());
+			keyspace = cassandraUnit.keyspace;
 			initialized = true;
 		}
 

--- a/src/main/java/org/cassandraunit/CassandraUnit.java
+++ b/src/main/java/org/cassandraunit/CassandraUnit.java
@@ -1,23 +1,38 @@
 package org.cassandraunit;
 
 import me.prettyprint.hector.api.Cluster;
+import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.factory.HFactory;
 
+import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.rules.ExternalResource;
 
 public class CassandraUnit extends ExternalResource {
 	public Cluster cluster;
+	public Keyspace keyspace;
+
+	private DataSet dataSet;
+
 	public String clusterName = "TestCluster";
 	public String host = "localhost:9171";
+
+	public CassandraUnit(DataSet dataSet) {
+		this.dataSet = dataSet;
+	}
 
 	@Override
 	protected void before() throws Exception {
 		/* start an embedded Cassandra */
 		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
 
+		/* create structure and load data */
+		DataLoader dataLoader = new DataLoader(clusterName, host);
+		dataLoader.load(dataSet);
+
 		/* get hector client object to query data in your test */
 		cluster = HFactory.getOrCreateCluster(clusterName, host);
+		keyspace = HFactory.createKeyspace(dataSet.getKeyspace().getName(), cluster);
 	}
 
 	

--- a/src/test/java/org/cassandraunit/CassandraStartAndLoadRuleTest.java
+++ b/src/test/java/org/cassandraunit/CassandraStartAndLoadRuleTest.java
@@ -1,18 +1,26 @@
 package org.cassandraunit;
 
+import static org.cassandraunit.SampleDataSetChecker.assertDataSetLoaded;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
+import org.cassandraunit.dataset.xml.ClassPathXmlDataSet;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class CassandraStartAndLoadRuleTest {
 
 	@Rule
-	public CassandraUnit cassandra = new CassandraUnit();
+	public CassandraUnit cassandra = new CassandraUnit(new ClassPathXmlDataSet("xml/datasetDefaultValues.xml"));
 	
 	@Test
 	public void shouldStartCassandraServer ()  {
 		assertThat(cassandra.cluster, notNullValue());
+	}
+	
+	@Test
+	public void shouldCreateStructureAndLoadData() throws Exception {
+		assertThat(cassandra.keyspace, notNullValue());
+		assertDataSetLoaded(cassandra.keyspace);
 	}
 }

--- a/src/test/java/org/cassandraunit/CassandraStartAndLoadTest.java
+++ b/src/test/java/org/cassandraunit/CassandraStartAndLoadTest.java
@@ -1,17 +1,8 @@
 package org.cassandraunit;
 
-import static org.hamcrest.Matchers.is;
+import static org.cassandraunit.SampleDataSetChecker.assertDataSetLoaded;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-
-import java.util.List;
-
-import me.prettyprint.cassandra.serializers.BytesArraySerializer;
-import me.prettyprint.hector.api.beans.OrderedRows;
-import me.prettyprint.hector.api.beans.Row;
-import me.prettyprint.hector.api.factory.HFactory;
-import me.prettyprint.hector.api.query.QueryResult;
-import me.prettyprint.hector.api.query.RangeSlicesQuery;
 
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.dataset.xml.ClassPathXmlDataSet;
@@ -32,31 +23,13 @@ public class CassandraStartAndLoadTest extends AbstractCassandraUnit4TestCase {
 	@Test
 	public void shouldWork() throws Exception {
 		assertThat(getKeyspace(), notNullValue());
-		queryAndVerify();
+		assertDataSetLoaded(getKeyspace());
 	}
 
 	@Test
 	public void shouldWorkToo() throws Exception {
 		assertThat(getKeyspace(), notNullValue());
-		queryAndVerify();
-	}
-
-	private void queryAndVerify() {
-		RangeSlicesQuery<byte[], byte[], byte[]> query = HFactory.createRangeSlicesQuery(getKeyspace(),
-				BytesArraySerializer.get(), BytesArraySerializer.get(), BytesArraySerializer.get());
-		query.setColumnFamily("beautifulColumnFamilyName");
-		query.setRange(null, null, false, Integer.MAX_VALUE);
-		QueryResult<OrderedRows<byte[], byte[], byte[]>> result = query.execute();
-		List<Row<byte[], byte[], byte[]>> rows = result.get().getList();
-		assertThat(rows.size(), is(3));
-		assertThat(rows.get(0).getKey(), is("key30".getBytes()));
-		assertThat(rows.get(0).getColumnSlice().getColumns().size(), is(2));
-		assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getName(), is("name31".getBytes()));
-		assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getValue(), is("value31".getBytes()));
-		assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getName(), is("name32".getBytes()));
-		assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getValue(), is("value32".getBytes()));
-		assertThat(rows.get(1).getKey(), is("key20".getBytes()));
-		assertThat(rows.get(2).getKey(), is("key10".getBytes()));
+		assertDataSetLoaded(getKeyspace());
 	}
 
 }

--- a/src/test/java/org/cassandraunit/SampleDataSetChecker.java
+++ b/src/test/java/org/cassandraunit/SampleDataSetChecker.java
@@ -1,0 +1,36 @@
+package org.cassandraunit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import me.prettyprint.cassandra.serializers.BytesArraySerializer;
+import me.prettyprint.hector.api.Keyspace;
+import me.prettyprint.hector.api.beans.OrderedRows;
+import me.prettyprint.hector.api.beans.Row;
+import me.prettyprint.hector.api.factory.HFactory;
+import me.prettyprint.hector.api.query.QueryResult;
+import me.prettyprint.hector.api.query.RangeSlicesQuery;
+
+public class SampleDataSetChecker {
+	
+	public static void assertDataSetLoaded(Keyspace keyspace) {
+		RangeSlicesQuery<byte[], byte[], byte[]> query = HFactory.createRangeSlicesQuery(keyspace,
+				BytesArraySerializer.get(), BytesArraySerializer.get(), BytesArraySerializer.get());
+		query.setColumnFamily("beautifulColumnFamilyName");
+		query.setRange(null, null, false, Integer.MAX_VALUE);
+		QueryResult<OrderedRows<byte[], byte[], byte[]>> result = query.execute();
+		List<Row<byte[], byte[], byte[]>> rows = result.get().getList();
+		assertThat(rows.size(), is(3));
+		assertThat(rows.get(0).getKey(), is("key30".getBytes()));
+		assertThat(rows.get(0).getColumnSlice().getColumns().size(), is(2));
+		assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getName(), is("name31".getBytes()));
+		assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getValue(), is("value31".getBytes()));
+		assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getName(), is("name32".getBytes()));
+		assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getValue(), is("value32".getBytes()));
+		assertThat(rows.get(1).getKey(), is("key20".getBytes()));
+		assertThat(rows.get(2).getKey(), is("key10".getBytes()));
+
+	}
+}


### PR DESCRIPTION
Junit @Rule allow to use cassandra unit services without enforcing a class extension.

Most of the code was extracted from AbstractCassandraUnit4TestCase.
