### PR TITLE
Fix Boolean getter on JAXB

### DIFF
--- a/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
+++ b/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
@@ -146,8 +146,8 @@ public abstract class AbstractXmlDataSet implements DataSet {
             columnFamily.setReadRepairChance(xmlColumnFamily.getReadRepairChance());
         }
 
-        if (xmlColumnFamily.isReplicationOnWrite() != null) {
-            columnFamily.setReplicationOnWrite(xmlColumnFamily.isReplicationOnWrite());
+        if (xmlColumnFamily.getReplicationOnWrite() != null) {
+            columnFamily.setReplicationOnWrite(xmlColumnFamily.getReplicationOnWrite());
         }
 
 


### PR DESCRIPTION
The current build is failing because of the is/get on the boolean "ReplicationOnWrite". This issue is something similar to this JAXB issue: http://java.net/jira/browse/JAXB-631
The project compiles just by changing the **isReplicationOnWrite** for **getReplicationOnWrite**.
