### PR TITLE
Deprecating stopEmbeddedCassandra()

### DIFF
--- a/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -118,13 +118,13 @@ public class EmbeddedCassandraServerHelper {
     }
 
     /**
-     * stop the embedded cassandra
+     * Now deprecated, previous version was not fully operating.
+     * This is now an empty method, will be pruned in future versions.
      */
+    @Deprecated
     public static void stopEmbeddedCassandra() {
-        executor.shutdown();
-        executor.shutdownNow();
-        cassandraDaemon = null;
-        log.debug("Cassandra is stopped");
+        log.warn("EmbeddedCassandraServerHelper.stopEmbeddedCassandra() is now deprecated, " +
+                "previous version was not fully operating");
     }
 
     /**

--- a/src/test/java/org/cassandraunit/utils/EmbeddedCassandraServerHelperTest.java
+++ b/src/test/java/org/cassandraunit/utils/EmbeddedCassandraServerHelperTest.java
@@ -4,7 +4,6 @@ import me.prettyprint.cassandra.service.CassandraHostConfigurator;
 import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.ddl.KeyspaceDefinition;
 import me.prettyprint.hector.api.factory.HFactory;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Random;
@@ -21,22 +20,13 @@ import static org.junit.Assert.assertThat;
 public class EmbeddedCassandraServerHelperTest {
 
 	@Test
-    @Ignore
 	public void shouldStartAndCleanAnEmbeddedCassandra() throws Exception {
 		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
 		testIfTheEmbeddedCassandraServerIsUpOnHost("127.0.0.1:9171");
-		EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
 		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
 		testIfTheEmbeddedCassandraServerIsUpOnHost("127.0.0.1:9171");
-		EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
-		EmbeddedCassandraServerHelper.stopEmbeddedCassandra();
-	}
-
-	@Test(expected = UnsupportedOperationException.class)
-    @Ignore
-	public void shouldNotStartTheEmbeddedCassandraServerWithAnotherCassandraYamlConf() throws Exception {
-		EmbeddedCassandraServerHelper.startEmbeddedCassandra("another-cassandra.yaml");
-
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
 	}
 
 	private void testIfTheEmbeddedCassandraServerIsUpOnHost(String hostAndPort) {


### PR DESCRIPTION
stopEmbeddedCassandra() was not really stopping Cassandra, we had problems with this cycle :
-start()
-load()
-stop()
-start() -> Fail

Method is now empty and deprecated
