### PR TITLE
#27: ComparatorTypes now accepts 'reversed' qualifiers. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /.settings
 /cassandra-unit.iml
 /.idea
+
+.DS_Store
+bin/

--- a/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
+++ b/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
@@ -1,321 +1,313 @@
 package org.cassandraunit.dataset.commons;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import me.prettyprint.hector.api.ddl.ColumnIndexType;
 import me.prettyprint.hector.api.ddl.ColumnType;
 import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import org.apache.commons.lang.StringUtils;
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.dataset.ParseException;
-import org.cassandraunit.model.*;
+import org.cassandraunit.model.ColumnFamilyModel;
+import org.cassandraunit.model.ColumnMetadataModel;
+import org.cassandraunit.model.ColumnModel;
+import org.cassandraunit.model.CompactionStrategyOptionModel;
+import org.cassandraunit.model.KeyspaceModel;
+import org.cassandraunit.model.RowModel;
+import org.cassandraunit.model.StrategyModel;
+import org.cassandraunit.model.SuperColumnModel;
 import org.cassandraunit.type.GenericType;
 import org.cassandraunit.type.GenericTypeEnum;
 import org.cassandraunit.utils.ComparatorTypeHelper;
 import org.cassandraunit.utils.TypeExtractor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre
  */
 public abstract class AbstractCommonsParserDataSet implements DataSet {
 
-    protected KeyspaceModel keyspace = null;
+	private static final String REVERSED_QUALIFIER = "(reversed=";
+	protected KeyspaceModel keyspace = null;
 
-    protected abstract ParsedKeyspace getParsedKeyspace();
+	protected abstract ParsedKeyspace getParsedKeyspace();
 
-    @Override
-    public KeyspaceModel getKeyspace() {
-        if (keyspace == null) {
-            mapParsedKeyspaceToModel(getParsedKeyspace());
-        }
-        return keyspace;
-    }
+	@Override
+	public KeyspaceModel getKeyspace() {
+		if (keyspace == null) {
+			mapParsedKeyspaceToModel(getParsedKeyspace());
+		}
+		return keyspace;
+	}
 
-    @Override
-    public List<ColumnFamilyModel> getColumnFamilies() {
-        if (keyspace == null) {
-            mapParsedKeyspaceToModel(getParsedKeyspace());
-        }
-        return keyspace.getColumnFamilies();
-    }
+	@Override
+	public List<ColumnFamilyModel> getColumnFamilies() {
+		if (keyspace == null) {
+			mapParsedKeyspaceToModel(getParsedKeyspace());
+		}
+		return keyspace.getColumnFamilies();
+	}
 
-    protected void mapParsedKeyspaceToModel(ParsedKeyspace parsedKeyspace) {
-        if (parsedKeyspace == null) {
-            throw new ParseException("dataSet is empty");
-        }
-        /* keyspace */
-        keyspace = new KeyspaceModel();
-        if (parsedKeyspace.getName() == null) {
-            throw new ParseException("Keyspace name is mandatory");
-        }
-        keyspace.setName(parsedKeyspace.getName());
+	protected void mapParsedKeyspaceToModel(ParsedKeyspace parsedKeyspace) {
+		if (parsedKeyspace == null) {
+			throw new ParseException("dataSet is empty");
+		}
+		/* keyspace */
+		keyspace = new KeyspaceModel();
+		if (parsedKeyspace.getName() == null) {
+			throw new ParseException("Keyspace name is mandatory");
+		}
+		keyspace.setName(parsedKeyspace.getName());
 
-        /* optional conf */
-        if (parsedKeyspace.getReplicationFactor() != 0) {
-            keyspace.setReplicationFactor(parsedKeyspace.getReplicationFactor());
-        }
+		/* optional conf */
+		if (parsedKeyspace.getReplicationFactor() != 0) {
+			keyspace.setReplicationFactor(parsedKeyspace.getReplicationFactor());
+		}
 
-        if (parsedKeyspace.getStrategy() != null) {
-            try {
-                keyspace.setStrategy(StrategyModel.fromValue(parsedKeyspace.getStrategy()));
-            } catch (IllegalArgumentException e) {
-                throw new ParseException("Invalid keyspace Strategy");
-            }
-        }
+		if (parsedKeyspace.getStrategy() != null) {
+			try {
+				keyspace.setStrategy(StrategyModel.fromValue(parsedKeyspace.getStrategy()));
+			} catch (IllegalArgumentException e) {
+				throw new ParseException("Invalid keyspace Strategy");
+			}
+		}
 
-        mapsParsedColumnFamiliesToColumnFamiliesModel(parsedKeyspace);
+		mapsParsedColumnFamiliesToColumnFamiliesModel(parsedKeyspace);
 
-    }
+	}
 
-    private void mapsParsedColumnFamiliesToColumnFamiliesModel(ParsedKeyspace parsedKeyspace) {
-        if (parsedKeyspace.getColumnFamilies() != null) {
-            /* there is column families to integrate */
-            for (ParsedColumnFamily parsedColumnFamily : parsedKeyspace.getColumnFamilies()) {
-                keyspace.getColumnFamilies().add(mapParsedColumnFamilyToColumnFamilyModel(parsedColumnFamily));
-            }
-        }
+	private void mapsParsedColumnFamiliesToColumnFamiliesModel(ParsedKeyspace parsedKeyspace) {
+		if (parsedKeyspace.getColumnFamilies() != null) {
+			/* there is column families to integrate */
+			for (ParsedColumnFamily parsedColumnFamily : parsedKeyspace.getColumnFamilies()) {
+				keyspace.getColumnFamilies().add(mapParsedColumnFamilyToColumnFamilyModel(parsedColumnFamily));
+			}
+		}
 
-    }
+	}
 
-    private ColumnFamilyModel mapParsedColumnFamilyToColumnFamilyModel(ParsedColumnFamily parsedColumnFamily) {
+	private ColumnFamilyModel mapParsedColumnFamilyToColumnFamilyModel(ParsedColumnFamily parsedColumnFamily) {
 
-        ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+		ColumnFamilyModel columnFamily = new ColumnFamilyModel();
 
-        /* structure information */
-        if (parsedColumnFamily == null || parsedColumnFamily.getName() == null) {
-            throw new ParseException("Column Family Name is missing");
-        }
-        columnFamily.setName(parsedColumnFamily.getName());
-        if (parsedColumnFamily.getType() != null) {
-            columnFamily.setType(ColumnType.valueOf(parsedColumnFamily.getType().toString()));
-        }
+		/* structure information */
+		if (parsedColumnFamily == null || parsedColumnFamily.getName() == null) {
+			throw new ParseException("Column Family Name is missing");
+		}
+		columnFamily.setName(parsedColumnFamily.getName());
+		if (parsedColumnFamily.getType() != null) {
+			columnFamily.setType(ColumnType.valueOf(parsedColumnFamily.getType().toString()));
+		}
 
-        columnFamily.setComment(parsedColumnFamily.getComment());
+		columnFamily.setComment(parsedColumnFamily.getComment());
 
-        if (parsedColumnFamily.getCompactionStrategy() != null) {
-            columnFamily.setCompactionStrategy(parsedColumnFamily.getCompactionStrategy());
-        }
+		if (parsedColumnFamily.getCompactionStrategy() != null) {
+			columnFamily.setCompactionStrategy(parsedColumnFamily.getCompactionStrategy());
+		}
 
-        if (parsedColumnFamily.getCompactionStrategyOptions() != null && !parsedColumnFamily.getCompactionStrategyOptions().isEmpty()) {
-            List<CompactionStrategyOptionModel> compactionStrategyOptionModels = new ArrayList<CompactionStrategyOptionModel>();
-            for (ParsedCompactionStrategyOption parsedCompactionStrategyOption : parsedColumnFamily.getCompactionStrategyOptions()) {
-                compactionStrategyOptionModels.add(new CompactionStrategyOptionModel(parsedCompactionStrategyOption.getName(), parsedCompactionStrategyOption.getValue()));
-            }
-            columnFamily.setCompactionStrategyOptions(compactionStrategyOptionModels);
-        }
+		if (parsedColumnFamily.getCompactionStrategyOptions() != null && !parsedColumnFamily.getCompactionStrategyOptions().isEmpty()) {
+			List<CompactionStrategyOptionModel> compactionStrategyOptionModels = new ArrayList<CompactionStrategyOptionModel>();
+			for (ParsedCompactionStrategyOption parsedCompactionStrategyOption : parsedColumnFamily.getCompactionStrategyOptions()) {
+				compactionStrategyOptionModels.add(new CompactionStrategyOptionModel(parsedCompactionStrategyOption.getName(), parsedCompactionStrategyOption
+						.getValue()));
+			}
+			columnFamily.setCompactionStrategyOptions(compactionStrategyOptionModels);
+		}
 
-        if (parsedColumnFamily.getGcGraceSeconds() != null) {
-            columnFamily.setGcGraceSeconds(parsedColumnFamily.getGcGraceSeconds());
-        }
+		if (parsedColumnFamily.getGcGraceSeconds() != null) {
+			columnFamily.setGcGraceSeconds(parsedColumnFamily.getGcGraceSeconds());
+		}
 
-        if (parsedColumnFamily.getMaxCompactionThreshold() != null) {
-            columnFamily.setMaxCompactionThreshold(parsedColumnFamily.getMaxCompactionThreshold());
-        }
+		if (parsedColumnFamily.getMaxCompactionThreshold() != null) {
+			columnFamily.setMaxCompactionThreshold(parsedColumnFamily.getMaxCompactionThreshold());
+		}
 
-        if (parsedColumnFamily.getMinCompactionThreshold() != null) {
-            columnFamily.setMinCompactionThreshold(parsedColumnFamily.getMinCompactionThreshold());
-        }
+		if (parsedColumnFamily.getMinCompactionThreshold() != null) {
+			columnFamily.setMinCompactionThreshold(parsedColumnFamily.getMinCompactionThreshold());
+		}
 
-        if (parsedColumnFamily.getReadRepairChance() != null) {
-            columnFamily.setReadRepairChance(parsedColumnFamily.getReadRepairChance());
-        }
+		if (parsedColumnFamily.getReadRepairChance() != null) {
+			columnFamily.setReadRepairChance(parsedColumnFamily.getReadRepairChance());
+		}
 
-        if (parsedColumnFamily.getReplicationOnWrite() != null) {
-            columnFamily.setReplicationOnWrite(parsedColumnFamily.getReplicationOnWrite());
-        }
+		if (parsedColumnFamily.getReplicationOnWrite() != null) {
+			columnFamily.setReplicationOnWrite(parsedColumnFamily.getReplicationOnWrite());
+		}
 
-        /* keyType */
-        GenericTypeEnum[] typesBelongingCompositeTypeForKeyType = null;
-        if (parsedColumnFamily.getKeyType() != null) {
-            ComparatorType keyType = ComparatorTypeHelper.verifyAndExtract(parsedColumnFamily.getKeyType());
-            columnFamily.setKeyType(keyType);
-            if (ComparatorType.COMPOSITETYPE.getTypeName().equals(keyType.getTypeName())) {
-                String keyTypeAlias = StringUtils.removeStart(parsedColumnFamily.getKeyType(),
-                        ComparatorType.COMPOSITETYPE.getTypeName());
-                columnFamily.setKeyTypeAlias(keyTypeAlias);
-                typesBelongingCompositeTypeForKeyType = ComparatorTypeHelper
-                        .extractGenericTypesFromTypeAlias(keyTypeAlias);
-            }
-        }
+		/* keyType */
+		GenericTypeEnum[] typesBelongingCompositeTypeForKeyType = null;
+		if (parsedColumnFamily.getKeyType() != null) {
+			ComparatorType keyType = ComparatorTypeHelper.verifyAndExtract(parsedColumnFamily.getKeyType());
+			columnFamily.setKeyType(keyType);
+			if (ComparatorType.COMPOSITETYPE.getTypeName().equals(keyType.getTypeName())) {
+				String keyTypeAlias = StringUtils.removeStart(parsedColumnFamily.getKeyType(), ComparatorType.COMPOSITETYPE.getTypeName());
+				columnFamily.setKeyTypeAlias(keyTypeAlias);
+				typesBelongingCompositeTypeForKeyType = ComparatorTypeHelper.extractGenericTypesFromTypeAlias(keyTypeAlias);
+			}
+		}
 
-        /* comparatorType */
-        GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType = null;
-        if (parsedColumnFamily.getComparatorType() != null) {
-            ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(parsedColumnFamily
-                    .getComparatorType());
-            columnFamily.setComparatorType(comparatorType);
-            if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
-                String comparatorTypeAlias = StringUtils.removeStart(parsedColumnFamily.getComparatorType(),
-                        ComparatorType.COMPOSITETYPE.getTypeName());
-                columnFamily.setComparatorTypeAlias(comparatorTypeAlias);
-                typesBelongingCompositeTypeForComparatorType = ComparatorTypeHelper
-                        .extractGenericTypesFromTypeAlias(comparatorTypeAlias);
-            }
-        }
+		/* comparatorType */
+		GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType = null;
+		final String parsedComparatorType = parsedColumnFamily.getComparatorType();
+		if (parsedComparatorType != null) {
+			ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(parsedComparatorType);
+			columnFamily.setComparatorType(comparatorType);
+			if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
+				String comparatorTypeAlias = StringUtils.removeStart(parsedComparatorType, ComparatorType.COMPOSITETYPE.getTypeName());
+				columnFamily.setComparatorTypeAlias(comparatorTypeAlias);
+				typesBelongingCompositeTypeForComparatorType = ComparatorTypeHelper.extractGenericTypesFromTypeAlias(comparatorTypeAlias);
+			} else if (StringUtils.containsIgnoreCase(parsedComparatorType, REVERSED_QUALIFIER)) {
+				int begin = StringUtils.indexOfIgnoreCase(parsedComparatorType, REVERSED_QUALIFIER);
+				int end = parsedComparatorType.length();
+				columnFamily.setComparatorTypeAlias(parsedComparatorType.substring(begin, end));
+			}
+		}
 
-        /* subComparatorType */
-        if (parsedColumnFamily.getSubComparatorType() != null) {
-            columnFamily.setSubComparatorType(ComparatorType.getByClassName(parsedColumnFamily.getSubComparatorType()
-                    .name()));
-        }
+		/* subComparatorType */
+		if (parsedColumnFamily.getSubComparatorType() != null) {
+			columnFamily.setSubComparatorType(ComparatorType.getByClassName(parsedColumnFamily.getSubComparatorType().name()));
+		}
 
-        if (parsedColumnFamily.getDefaultColumnValueType() != null) {
-            columnFamily.setDefaultColumnValueType(ComparatorType.getByClassName(parsedColumnFamily
-                    .getDefaultColumnValueType().name()));
-        }
+		if (parsedColumnFamily.getDefaultColumnValueType() != null) {
+			columnFamily.setDefaultColumnValueType(ComparatorType.getByClassName(parsedColumnFamily.getDefaultColumnValueType().name()));
+		}
 
-        columnFamily.setColumnsMetadata(mapParsedColumsMetadataToColumnsMetadata(parsedColumnFamily
-                .getColumnsMetadata(),
-                columnFamily.getComparatorType(),
-                typesBelongingCompositeTypeForComparatorType));
+		columnFamily.setColumnsMetadata(mapParsedColumsMetadataToColumnsMetadata(parsedColumnFamily.getColumnsMetadata(), columnFamily.getComparatorType(),
+				typesBelongingCompositeTypeForComparatorType));
 
-        /* data information */
-        columnFamily.setRows(mapParsedRowsToRowsModel(parsedColumnFamily, columnFamily.getKeyType(),
-                typesBelongingCompositeTypeForKeyType, columnFamily.getComparatorType(),
-                typesBelongingCompositeTypeForComparatorType, columnFamily.getSubComparatorType(),
-                columnFamily.getDefaultColumnValueType()));
+		/* data information */
+		columnFamily.setRows(mapParsedRowsToRowsModel(parsedColumnFamily, columnFamily.getKeyType(), typesBelongingCompositeTypeForKeyType,
+				columnFamily.getComparatorType(), typesBelongingCompositeTypeForComparatorType, columnFamily.getSubComparatorType(),
+				columnFamily.getDefaultColumnValueType()));
 
-        return columnFamily;
-    }
+		return columnFamily;
+	}
 
-    private List<ColumnMetadataModel> mapParsedColumsMetadataToColumnsMetadata(
-            List<ParsedColumnMetadata> parsedColumnsMetadata,
-            ComparatorType comparatorType,
-            GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
-        List<ColumnMetadataModel> columnMetadatas = new ArrayList<ColumnMetadataModel>();
-        for (ParsedColumnMetadata parsedColumnMetadata : parsedColumnsMetadata) {
-            columnMetadatas.add(mapParsedColumMetadataToColumnMetadata(parsedColumnMetadata, comparatorType, typesBelongingCompositeTypeForComparatorType));
-        }
-        return columnMetadatas;
-    }
+	private List<ColumnMetadataModel> mapParsedColumsMetadataToColumnsMetadata(List<ParsedColumnMetadata> parsedColumnsMetadata, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
+		List<ColumnMetadataModel> columnMetadatas = new ArrayList<ColumnMetadataModel>();
+		for (ParsedColumnMetadata parsedColumnMetadata : parsedColumnsMetadata) {
+			columnMetadatas.add(mapParsedColumMetadataToColumnMetadata(parsedColumnMetadata, comparatorType, typesBelongingCompositeTypeForComparatorType));
+		}
+		return columnMetadatas;
+	}
 
-    private ColumnMetadataModel mapParsedColumMetadataToColumnMetadata(ParsedColumnMetadata parsedColumnMetadata,
-                                                                       ComparatorType comparatorType,
-                                                                       GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
-        if (parsedColumnMetadata.getName() == null) {
-            throw new ParseException("column metadata name can't be empty");
-        }
+	private ColumnMetadataModel mapParsedColumMetadataToColumnMetadata(ParsedColumnMetadata parsedColumnMetadata, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
+		if (parsedColumnMetadata.getName() == null) {
+			throw new ParseException("column metadata name can't be empty");
+		}
 
-        if (parsedColumnMetadata.getValidationClass() == null) {
-            throw new ParseException("column metadata validation class can't be empty");
-        }
+		if (parsedColumnMetadata.getValidationClass() == null) {
+			throw new ParseException("column metadata validation class can't be empty");
+		}
 
-        ColumnMetadataModel columnMetadata = new ColumnMetadataModel();
-        columnMetadata.setColumnName(TypeExtractor.constructGenericType(parsedColumnMetadata.getName(), comparatorType,
-                typesBelongingCompositeTypeForComparatorType));
-        columnMetadata.setValidationClass(ComparatorType.getByClassName(parsedColumnMetadata.getValidationClass()
-                .name()));
-        if (parsedColumnMetadata.getIndexType() != null) {
-            columnMetadata.setColumnIndexType(ColumnIndexType.valueOf(parsedColumnMetadata.getIndexType().name()));
-        }
+		ColumnMetadataModel columnMetadata = new ColumnMetadataModel();
+		columnMetadata.setColumnName(TypeExtractor.constructGenericType(parsedColumnMetadata.getName(), comparatorType,
+				typesBelongingCompositeTypeForComparatorType));
+		columnMetadata.setValidationClass(ComparatorType.getByClassName(parsedColumnMetadata.getValidationClass().name()));
+		if (parsedColumnMetadata.getIndexType() != null) {
+			columnMetadata.setColumnIndexType(ColumnIndexType.valueOf(parsedColumnMetadata.getIndexType().name()));
+		}
 
-        if (parsedColumnMetadata.getIndexName() != null) {
-            columnMetadata.setIndexName(parsedColumnMetadata.getIndexName());
-        }
+		if (parsedColumnMetadata.getIndexName() != null) {
+			columnMetadata.setIndexName(parsedColumnMetadata.getIndexName());
+		}
 
-        return columnMetadata;
-    }
+		return columnMetadata;
+	}
 
-    private List<RowModel> mapParsedRowsToRowsModel(ParsedColumnFamily parsedColumnFamily, ComparatorType keyType,
-                                                    GenericTypeEnum[] typesBelongingCompositeTypeForKeyType, ComparatorType comparatorType,
-                                                    GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType subComparatorType,
-                                                    ComparatorType defaultColumnValueType) {
-        List<RowModel> rowsModel = new ArrayList<RowModel>();
-        for (ParsedRow jsonRow : parsedColumnFamily.getRows()) {
-            rowsModel.add(mapsParsedRowToRowModel(parsedColumnFamily.getColumnsMetadata(), jsonRow, keyType, typesBelongingCompositeTypeForKeyType,
-                    comparatorType, typesBelongingCompositeTypeForComparatorType, subComparatorType,
-                    defaultColumnValueType));
-        }
-        return rowsModel;
-    }
+	private List<RowModel> mapParsedRowsToRowsModel(ParsedColumnFamily parsedColumnFamily, ComparatorType keyType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForKeyType, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
+		List<RowModel> rowsModel = new ArrayList<RowModel>();
+		for (ParsedRow jsonRow : parsedColumnFamily.getRows()) {
+			rowsModel.add(mapsParsedRowToRowModel(parsedColumnFamily.getColumnsMetadata(), jsonRow, keyType, typesBelongingCompositeTypeForKeyType,
+					comparatorType, typesBelongingCompositeTypeForComparatorType, subComparatorType, defaultColumnValueType));
+		}
+		return rowsModel;
+	}
 
-    private RowModel mapsParsedRowToRowModel(List<ParsedColumnMetadata> metaData, ParsedRow parsedRow, ComparatorType keyType,
-                                             GenericTypeEnum[] typesBelongingCompositeTypeForKeyType, ComparatorType comparatorType,
-                                             GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType subComparatorType,
-                                             ComparatorType defaultColumnValueType) {
-        RowModel row = new RowModel();
+	private RowModel mapsParsedRowToRowModel(List<ParsedColumnMetadata> metaData, ParsedRow parsedRow, ComparatorType keyType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForKeyType, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
+		RowModel row = new RowModel();
 
-        row.setKey(TypeExtractor.constructGenericType(parsedRow.getKey(), keyType,
-                typesBelongingCompositeTypeForKeyType));
+		row.setKey(TypeExtractor.constructGenericType(parsedRow.getKey(), keyType, typesBelongingCompositeTypeForKeyType));
 
-        row.setColumns(mapParsedColumnsToColumnsModel(metaData, parsedRow.getColumns(), comparatorType,
-                typesBelongingCompositeTypeForComparatorType, defaultColumnValueType));
-        row.setSuperColumns(mapParsedSuperColumnsToSuperColumnsModel(metaData, parsedRow.getSuperColumns(), comparatorType,
-                subComparatorType, defaultColumnValueType));
-        return row;
-    }
+		row.setColumns(mapParsedColumnsToColumnsModel(metaData, parsedRow.getColumns(), comparatorType, typesBelongingCompositeTypeForComparatorType,
+				defaultColumnValueType));
+		row.setSuperColumns(mapParsedSuperColumnsToSuperColumnsModel(metaData, parsedRow.getSuperColumns(), comparatorType, subComparatorType,
+				defaultColumnValueType));
+		return row;
+	}
 
-    private List<SuperColumnModel> mapParsedSuperColumnsToSuperColumnsModel(List<ParsedColumnMetadata> metaData, List<ParsedSuperColumn> parsedSuperColumns,
-                                                                            ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
-        List<SuperColumnModel> columnsModel = new ArrayList<SuperColumnModel>();
-        for (ParsedSuperColumn parsedSuperColumn : parsedSuperColumns) {
-            columnsModel.add(mapParsedSuperColumnToSuperColumnModel(metaData, parsedSuperColumn, comparatorType,
-                    subComparatorType, defaultColumnValueType));
-        }
+	private List<SuperColumnModel> mapParsedSuperColumnsToSuperColumnsModel(List<ParsedColumnMetadata> metaData, List<ParsedSuperColumn> parsedSuperColumns,
+			ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
+		List<SuperColumnModel> columnsModel = new ArrayList<SuperColumnModel>();
+		for (ParsedSuperColumn parsedSuperColumn : parsedSuperColumns) {
+			columnsModel.add(mapParsedSuperColumnToSuperColumnModel(metaData, parsedSuperColumn, comparatorType, subComparatorType, defaultColumnValueType));
+		}
 
-        return columnsModel;
-    }
+		return columnsModel;
+	}
 
-    private SuperColumnModel mapParsedSuperColumnToSuperColumnModel(List<ParsedColumnMetadata> metaData, ParsedSuperColumn parsedSuperColumn,
-                                                                    ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
-        SuperColumnModel superColumnModel = new SuperColumnModel();
+	private SuperColumnModel mapParsedSuperColumnToSuperColumnModel(List<ParsedColumnMetadata> metaData, ParsedSuperColumn parsedSuperColumn,
+			ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
+		SuperColumnModel superColumnModel = new SuperColumnModel();
 
-        superColumnModel.setName(new GenericType(parsedSuperColumn.getName(), GenericTypeEnum.fromValue(comparatorType
-                .getTypeName())));
+		superColumnModel.setName(new GenericType(parsedSuperColumn.getName(), GenericTypeEnum.fromValue(comparatorType.getTypeName())));
 
-        superColumnModel.setColumns(mapParsedColumnsToColumnsModel(metaData, parsedSuperColumn.getColumns(), subComparatorType,
-                null, defaultColumnValueType));
-        return superColumnModel;
-    }
+		superColumnModel.setColumns(mapParsedColumnsToColumnsModel(metaData, parsedSuperColumn.getColumns(), subComparatorType, null, defaultColumnValueType));
+		return superColumnModel;
+	}
 
-    private List<ColumnModel> mapParsedColumnsToColumnsModel(List<ParsedColumnMetadata> metaData, List<ParsedColumn> parsedColumns,
-                                                             ComparatorType comparatorType, GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType,
-                                                             ComparatorType defaultColumnValueType) {
-        List<ColumnModel> columnsModel = new ArrayList<ColumnModel>();
-        for (ParsedColumn jsonColumn : parsedColumns) {
-            ParsedColumnMetadata columnMetaData = null;
-            for (ParsedColumnMetadata tmpMetaData : metaData) {
-                if (tmpMetaData.getName().equals(jsonColumn.getName())) {
-                    columnMetaData = tmpMetaData;
-                    break;
-                }
-            }
-            columnsModel.add(mapParsedColumnToColumnModel(columnMetaData, jsonColumn, comparatorType,
-                    typesBelongingCompositeTypeForComparatorType, defaultColumnValueType));
-        }
-        return columnsModel;
-    }
+	private List<ColumnModel> mapParsedColumnsToColumnsModel(List<ParsedColumnMetadata> metaData, List<ParsedColumn> parsedColumns,
+			ComparatorType comparatorType, GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType defaultColumnValueType) {
+		List<ColumnModel> columnsModel = new ArrayList<ColumnModel>();
+		for (ParsedColumn jsonColumn : parsedColumns) {
+			ParsedColumnMetadata columnMetaData = null;
+			for (ParsedColumnMetadata tmpMetaData : metaData) {
+				if (tmpMetaData.getName().equals(jsonColumn.getName())) {
+					columnMetaData = tmpMetaData;
+					break;
+				}
+			}
+			columnsModel.add(mapParsedColumnToColumnModel(columnMetaData, jsonColumn, comparatorType, typesBelongingCompositeTypeForComparatorType,
+					defaultColumnValueType));
+		}
+		return columnsModel;
+	}
 
-    private ColumnModel mapParsedColumnToColumnModel(ParsedColumnMetadata metaData, ParsedColumn parsedColumn, ComparatorType comparatorType,
-                                                     GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType defaultColumnValueType) {
-        ColumnModel columnModel = new ColumnModel();
+	private ColumnModel mapParsedColumnToColumnModel(ParsedColumnMetadata metaData, ParsedColumn parsedColumn, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType defaultColumnValueType) {
+		ColumnModel columnModel = new ColumnModel();
 
-        columnModel.setName(TypeExtractor.constructGenericType(parsedColumn.getName(), comparatorType,
-                typesBelongingCompositeTypeForComparatorType));
+		columnModel.setName(TypeExtractor.constructGenericType(parsedColumn.getName(), comparatorType, typesBelongingCompositeTypeForComparatorType));
 
-        if (ComparatorType.COUNTERTYPE.getClassName().equals(defaultColumnValueType.getClassName())
-                && TypeExtractor.containFunctions(parsedColumn.getValue())) {
-            throw new ParseException("Impossible to override Column value into a Counter column family");
-        }
+		if (ComparatorType.COUNTERTYPE.getClassName().equals(defaultColumnValueType.getClassName()) && TypeExtractor.containFunctions(parsedColumn.getValue())) {
+			throw new ParseException("Impossible to override Column value into a Counter column family");
+		}
 
-        GenericType columnValue = null;
-        if (parsedColumn.getValue() != null) {
-            if (metaData != null && !TypeExtractor.containFunctions(parsedColumn.getValue())) {
-                GenericTypeEnum genTypeEnum = GenericTypeEnum.fromValue(metaData.getValidationClass().name());
-                columnValue = new GenericType(parsedColumn.getValue(), genTypeEnum);
-            } else {
-                columnValue = TypeExtractor.extract(parsedColumn.getValue(), defaultColumnValueType);
-            }
-        }
-        columnModel.setValue(columnValue);
-        String timestamp = parsedColumn.getTimestamp();
-        if(timestamp != null) {
-            columnModel.setTimestamp(Long.valueOf(timestamp));
-        } else {
-            columnModel.setTimestamp(null);
-        }
-        return columnModel;
-    }
+		GenericType columnValue = null;
+		if (parsedColumn.getValue() != null) {
+			if (metaData != null && !TypeExtractor.containFunctions(parsedColumn.getValue())) {
+				GenericTypeEnum genTypeEnum = GenericTypeEnum.fromValue(metaData.getValidationClass().name());
+				columnValue = new GenericType(parsedColumn.getValue(), genTypeEnum);
+			} else {
+				columnValue = TypeExtractor.extract(parsedColumn.getValue(), defaultColumnValueType);
+			}
+		}
+		columnModel.setValue(columnValue);
+		String timestamp = parsedColumn.getTimestamp();
+		if (timestamp != null) {
+			columnModel.setTimestamp(Long.valueOf(timestamp));
+		} else {
+			columnModel.setTimestamp(null);
+		}
+		return columnModel;
+	}
 
 }

--- a/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
+++ b/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
@@ -1,398 +1,397 @@
 package org.cassandraunit.dataset.xml;
 
-import me.prettyprint.hector.api.ddl.ColumnIndexType;
-import me.prettyprint.hector.api.ddl.ColumnType;
-import me.prettyprint.hector.api.ddl.ComparatorType;
-import org.apache.commons.lang.StringUtils;
-import org.cassandraunit.dataset.DataSet;
-import org.cassandraunit.dataset.ParseException;
-import org.cassandraunit.model.*;
-import org.cassandraunit.type.GenericType;
-import org.cassandraunit.type.GenericTypeEnum;
-import org.cassandraunit.utils.ComparatorTypeHelper;
-import org.cassandraunit.utils.TypeExtractor;
-import org.xml.sax.SAXException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
+
+import me.prettyprint.hector.api.ddl.ColumnIndexType;
+import me.prettyprint.hector.api.ddl.ColumnType;
+import me.prettyprint.hector.api.ddl.ComparatorType;
+
+import org.apache.commons.lang.StringUtils;
+import org.cassandraunit.dataset.DataSet;
+import org.cassandraunit.dataset.ParseException;
+import org.cassandraunit.model.ColumnFamilyModel;
+import org.cassandraunit.model.ColumnMetadataModel;
+import org.cassandraunit.model.ColumnModel;
+import org.cassandraunit.model.CompactionStrategyOptionModel;
+import org.cassandraunit.model.KeyspaceModel;
+import org.cassandraunit.model.RowModel;
+import org.cassandraunit.model.StrategyModel;
+import org.cassandraunit.model.SuperColumnModel;
+import org.cassandraunit.type.GenericType;
+import org.cassandraunit.type.GenericTypeEnum;
+import org.cassandraunit.utils.ComparatorTypeHelper;
+import org.cassandraunit.utils.TypeExtractor;
+import org.xml.sax.SAXException;
 
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre
  */
 public abstract class AbstractXmlDataSet implements DataSet {
 
-    private String dataSetLocation = null;
+	private static final String REVERSED_QUALIFIER = "(reversed=";
 
-    private KeyspaceModel keyspace = null;
+	private String dataSetLocation = null;
 
-    public AbstractXmlDataSet(String dataSetLocation) {
-        this.dataSetLocation = dataSetLocation;
-        if (getInputDataSetLocation(dataSetLocation) == null) {
-            throw new ParseException("Dataset not found");
-        }
-    }
+	private KeyspaceModel keyspace = null;
 
-    private org.cassandraunit.dataset.xml.Keyspace getXmlKeyspace() {
-        InputStream inputDataSetLocation = getInputDataSetLocation(dataSetLocation);
-        if (inputDataSetLocation == null) {
-            throw new ParseException("Dataset not found in classpath");
-        }
+	public AbstractXmlDataSet(String dataSetLocation) {
+		this.dataSetLocation = dataSetLocation;
+		if (getInputDataSetLocation(dataSetLocation) == null) {
+			throw new ParseException("Dataset not found");
+		}
+	}
 
-        try {
-            Unmarshaller unmarshaller = getUnmarshaller();
-            org.cassandraunit.dataset.xml.Keyspace xmlKeyspace = (org.cassandraunit.dataset.xml.Keyspace) unmarshaller
-                    .unmarshal(inputDataSetLocation);
-            return xmlKeyspace;
-        } catch (JAXBException e) {
-            throw new ParseException(e);
-        } catch (SAXException e) {
-            throw new ParseException(e);
-        } catch (URISyntaxException e) {
-            throw new ParseException(e);
-        }
+	private org.cassandraunit.dataset.xml.Keyspace getXmlKeyspace() {
+		InputStream inputDataSetLocation = getInputDataSetLocation(dataSetLocation);
+		if (inputDataSetLocation == null) {
+			throw new ParseException("Dataset not found in classpath");
+		}
 
-    }
+		try {
+			Unmarshaller unmarshaller = getUnmarshaller();
+			org.cassandraunit.dataset.xml.Keyspace xmlKeyspace = (org.cassandraunit.dataset.xml.Keyspace) unmarshaller.unmarshal(inputDataSetLocation);
+			return xmlKeyspace;
+		} catch (JAXBException e) {
+			throw new ParseException(e);
+		} catch (SAXException e) {
+			throw new ParseException(e);
+		} catch (URISyntaxException e) {
+			throw new ParseException(e);
+		}
 
-    protected abstract InputStream getInputDataSetLocation(String dataSetLocation);
+	}
 
-    private Unmarshaller getUnmarshaller() throws JAXBException, SAXException, URISyntaxException {
-        JAXBContext jc = JAXBContext.newInstance(org.cassandraunit.dataset.xml.Keyspace.class);
-        Unmarshaller unmarshaller = jc.createUnmarshaller();
+	protected abstract InputStream getInputDataSetLocation(String dataSetLocation);
 
-        SchemaFactory sf = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+	private Unmarshaller getUnmarshaller() throws JAXBException, SAXException, URISyntaxException {
+		JAXBContext jc = JAXBContext.newInstance(org.cassandraunit.dataset.xml.Keyspace.class);
+		Unmarshaller unmarshaller = jc.createUnmarshaller();
 
-        Schema schema = sf.newSchema(this.getClass().getResource("/dataset.xsd"));
+		SchemaFactory sf = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
-        unmarshaller.setSchema(schema);
+		Schema schema = sf.newSchema(this.getClass().getResource("/dataset.xsd"));
 
-        return unmarshaller;
-    }
+		unmarshaller.setSchema(schema);
 
-    private void mapXmlKeyspaceToModel(org.cassandraunit.dataset.xml.Keyspace xmlKeyspace) {
+		return unmarshaller;
+	}
 
-        /* keyspace */
-        keyspace = new KeyspaceModel();
-        keyspace.setName(xmlKeyspace.getName());
+	private void mapXmlKeyspaceToModel(org.cassandraunit.dataset.xml.Keyspace xmlKeyspace) {
 
-        /* optional conf */
-        if (xmlKeyspace.getReplicationFactor() != null) {
-            keyspace.setReplicationFactor(xmlKeyspace.getReplicationFactor());
-        }
+		/* keyspace */
+		keyspace = new KeyspaceModel();
+		keyspace.setName(xmlKeyspace.getName());
 
-        if (xmlKeyspace.getStrategy() != null) {
-            keyspace.setStrategy(StrategyModel.fromValue(xmlKeyspace.getStrategy().value()));
-        }
+		/* optional conf */
+		if (xmlKeyspace.getReplicationFactor() != null) {
+			keyspace.setReplicationFactor(xmlKeyspace.getReplicationFactor());
+		}
 
-        mapsXmlColumnFamiliesToColumnFamiliesModel(xmlKeyspace);
-    }
+		if (xmlKeyspace.getStrategy() != null) {
+			keyspace.setStrategy(StrategyModel.fromValue(xmlKeyspace.getStrategy().value()));
+		}
 
-    private void mapsXmlColumnFamiliesToColumnFamiliesModel(org.cassandraunit.dataset.xml.Keyspace xmlKeyspace) {
+		mapsXmlColumnFamiliesToColumnFamiliesModel(xmlKeyspace);
+	}
 
-        if (xmlKeyspace.getColumnFamilies() != null) {
-            /* there is column families to integrate */
-            for (org.cassandraunit.dataset.xml.ColumnFamily xmlColumnFamily : xmlKeyspace.getColumnFamilies()
-                    .getColumnFamily()) {
-                keyspace.getColumnFamilies().add(mapXmlColumnFamilyToColumnFamilyModel(xmlColumnFamily));
-            }
-        }
-    }
+	private void mapsXmlColumnFamiliesToColumnFamiliesModel(org.cassandraunit.dataset.xml.Keyspace xmlKeyspace) {
 
-    private ColumnFamilyModel mapXmlColumnFamilyToColumnFamilyModel(
-            org.cassandraunit.dataset.xml.ColumnFamily xmlColumnFamily) {
+		if (xmlKeyspace.getColumnFamilies() != null) {
+			/* there is column families to integrate */
+			for (org.cassandraunit.dataset.xml.ColumnFamily xmlColumnFamily : xmlKeyspace.getColumnFamilies().getColumnFamily()) {
+				keyspace.getColumnFamilies().add(mapXmlColumnFamilyToColumnFamilyModel(xmlColumnFamily));
+			}
+		}
+	}
 
-        ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+	private ColumnFamilyModel mapXmlColumnFamilyToColumnFamilyModel(org.cassandraunit.dataset.xml.ColumnFamily xmlColumnFamily) {
 
-        /* structure information */
-        columnFamily.setName(xmlColumnFamily.getName());
-        if (xmlColumnFamily.getType() != null) {
-            columnFamily.setType(ColumnType.valueOf(xmlColumnFamily.getType().toString()));
-        }
-        columnFamily.setComment(xmlColumnFamily.getComment());
+		ColumnFamilyModel columnFamily = new ColumnFamilyModel();
 
-        if (xmlColumnFamily.getCompactionStrategy() != null) {
-            columnFamily.setCompactionStrategy(xmlColumnFamily.getCompactionStrategy());
-        }
+		/* structure information */
+		columnFamily.setName(xmlColumnFamily.getName());
+		if (xmlColumnFamily.getType() != null) {
+			columnFamily.setType(ColumnType.valueOf(xmlColumnFamily.getType().toString()));
+		}
+		columnFamily.setComment(xmlColumnFamily.getComment());
 
-        if (xmlColumnFamily.getCompactionStrategyOptions() != null) {
-            List<CompactionStrategyOptionModel> compactionStrategyOptionModels = new ArrayList<CompactionStrategyOptionModel>();
-            for (CompactionStrategyOption compactionStrategyOption : xmlColumnFamily.getCompactionStrategyOptions().getCompactionStrategyOption()) {
-                compactionStrategyOptionModels.add(new CompactionStrategyOptionModel(compactionStrategyOption.getName(), compactionStrategyOption.getValue()));
-            }
-            columnFamily.setCompactionStrategyOptions(compactionStrategyOptionModels);
-        }
+		if (xmlColumnFamily.getCompactionStrategy() != null) {
+			columnFamily.setCompactionStrategy(xmlColumnFamily.getCompactionStrategy());
+		}
 
-        if (xmlColumnFamily.getGcGraceSeconds() != null) {
-            columnFamily.setGcGraceSeconds(xmlColumnFamily.getGcGraceSeconds());
-        }
+		if (xmlColumnFamily.getCompactionStrategyOptions() != null) {
+			List<CompactionStrategyOptionModel> compactionStrategyOptionModels = new ArrayList<CompactionStrategyOptionModel>();
+			for (CompactionStrategyOption compactionStrategyOption : xmlColumnFamily.getCompactionStrategyOptions().getCompactionStrategyOption()) {
+				compactionStrategyOptionModels.add(new CompactionStrategyOptionModel(compactionStrategyOption.getName(), compactionStrategyOption.getValue()));
+			}
+			columnFamily.setCompactionStrategyOptions(compactionStrategyOptionModels);
+		}
 
-        if (xmlColumnFamily.getMaxCompactionThreshold() != null) {
-            columnFamily.setMaxCompactionThreshold(xmlColumnFamily.getMaxCompactionThreshold());
-        }
+		if (xmlColumnFamily.getGcGraceSeconds() != null) {
+			columnFamily.setGcGraceSeconds(xmlColumnFamily.getGcGraceSeconds());
+		}
 
-        if (xmlColumnFamily.getMinCompactionThreshold() != null) {
-            columnFamily.setMinCompactionThreshold(xmlColumnFamily.getMinCompactionThreshold());
-        }
+		if (xmlColumnFamily.getMaxCompactionThreshold() != null) {
+			columnFamily.setMaxCompactionThreshold(xmlColumnFamily.getMaxCompactionThreshold());
+		}
 
-        if (xmlColumnFamily.getReadRepairChance() != null) {
-            columnFamily.setReadRepairChance(xmlColumnFamily.getReadRepairChance());
-        }
+		if (xmlColumnFamily.getMinCompactionThreshold() != null) {
+			columnFamily.setMinCompactionThreshold(xmlColumnFamily.getMinCompactionThreshold());
+		}
 
-        if (xmlColumnFamily.getReplicationOnWrite() != null) {
-            columnFamily.setReplicationOnWrite(xmlColumnFamily.getReplicationOnWrite());
-        }
+		if (xmlColumnFamily.getReadRepairChance() != null) {
+			columnFamily.setReadRepairChance(xmlColumnFamily.getReadRepairChance());
+		}
 
+		if (xmlColumnFamily.getReplicationOnWrite() != null) {
+			columnFamily.setReplicationOnWrite(xmlColumnFamily.getReplicationOnWrite());
+		}
 
-        GenericTypeEnum[] typesBelongingCompositeTypeForKeyType = null;
-        if (xmlColumnFamily.getKeyType() != null) {
-            ComparatorType keyType = ComparatorTypeHelper.verifyAndExtract(xmlColumnFamily.getKeyType());
-            columnFamily.setKeyType(keyType);
-            if (ComparatorType.COMPOSITETYPE.getTypeName().equals(keyType.getTypeName())) {
-                String keyTypeAlias = StringUtils.removeStart(xmlColumnFamily.getKeyType(),
-                        ComparatorType.COMPOSITETYPE.getTypeName());
-                columnFamily.setKeyTypeAlias(keyTypeAlias);
-                typesBelongingCompositeTypeForKeyType = ComparatorTypeHelper
-                        .extractGenericTypesFromTypeAlias(keyTypeAlias);
-            }
-        }
+		GenericTypeEnum[] typesBelongingCompositeTypeForKeyType = null;
+		if (xmlColumnFamily.getKeyType() != null) {
+			ComparatorType keyType = ComparatorTypeHelper.verifyAndExtract(xmlColumnFamily.getKeyType());
+			columnFamily.setKeyType(keyType);
+			if (ComparatorType.COMPOSITETYPE.getTypeName().equals(keyType.getTypeName())) {
+				String keyTypeAlias = StringUtils.removeStart(xmlColumnFamily.getKeyType(), ComparatorType.COMPOSITETYPE.getTypeName());
+				columnFamily.setKeyTypeAlias(keyTypeAlias);
+				typesBelongingCompositeTypeForKeyType = ComparatorTypeHelper.extractGenericTypesFromTypeAlias(keyTypeAlias);
+			}
+		}
 
-        GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType = null;
-        if (xmlColumnFamily.getComparatorType() != null) {
-            ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(xmlColumnFamily.getComparatorType());
-            columnFamily.setComparatorType(comparatorType);
-            if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
-                String comparatorTypeAlias = StringUtils.removeStart(xmlColumnFamily.getComparatorType(),
-                        ComparatorType.COMPOSITETYPE.getTypeName());
-                columnFamily.setComparatorTypeAlias(comparatorTypeAlias);
-                typesBelongingCompositeTypeForComparatorType = ComparatorTypeHelper
-                        .extractGenericTypesFromTypeAlias(comparatorTypeAlias);
-            }
-        }
+		GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType = null;
+		final String xmlComparatorType = xmlColumnFamily.getComparatorType();
+		if (xmlComparatorType != null) {
+			ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(xmlComparatorType);
+			columnFamily.setComparatorType(comparatorType);
+			if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
+				String comparatorTypeAlias = StringUtils.removeStart(xmlComparatorType, ComparatorType.COMPOSITETYPE.getTypeName());
+				columnFamily.setComparatorTypeAlias(comparatorTypeAlias);
+				typesBelongingCompositeTypeForComparatorType = ComparatorTypeHelper.extractGenericTypesFromTypeAlias(comparatorTypeAlias);
+			} else if (StringUtils.containsIgnoreCase(xmlComparatorType, REVERSED_QUALIFIER)) {
+				int begin = StringUtils.indexOfIgnoreCase(xmlComparatorType, REVERSED_QUALIFIER);
+				int end = xmlComparatorType.length();
+				columnFamily.setComparatorTypeAlias(xmlComparatorType.substring(begin, end));
+			}
+		}
 
-        if (xmlColumnFamily.getSubComparatorType() != null) {
-            columnFamily.setSubComparatorType(ComparatorType.getByClassName(xmlColumnFamily.getSubComparatorType()
-                    .value()));
-        }
+		if (xmlColumnFamily.getSubComparatorType() != null) {
+			columnFamily.setSubComparatorType(ComparatorType.getByClassName(xmlColumnFamily.getSubComparatorType().value()));
+		}
 
-        if (xmlColumnFamily.getDefaultColumnValueType() != null) {
-            columnFamily.setDefaultColumnValueType(ComparatorType.getByClassName(xmlColumnFamily
-                    .getDefaultColumnValueType().value()));
-        }
+		if (xmlColumnFamily.getDefaultColumnValueType() != null) {
+			columnFamily.setDefaultColumnValueType(ComparatorType.getByClassName(xmlColumnFamily.getDefaultColumnValueType().value()));
+		}
 
-        columnFamily.setColumnsMetadata(mapXmlColumsMetadataToColumnsMetadata(xmlColumnFamily.getColumnMetadata(),
-                columnFamily.getComparatorType(),
-                typesBelongingCompositeTypeForComparatorType));
+		columnFamily.setColumnsMetadata(mapXmlColumsMetadataToColumnsMetadata(xmlColumnFamily.getColumnMetadata(), columnFamily.getComparatorType(),
+				typesBelongingCompositeTypeForComparatorType));
 
-        /* data information */
-        columnFamily.setRows(mapXmlRowsToRowsModel(xmlColumnFamily, columnFamily.getKeyType(),
-                typesBelongingCompositeTypeForKeyType, columnFamily.getComparatorType(),
-                typesBelongingCompositeTypeForComparatorType, columnFamily.getSubComparatorType(),
-                columnFamily.getDefaultColumnValueType()));
+		/* data information */
+		columnFamily.setRows(mapXmlRowsToRowsModel(xmlColumnFamily, columnFamily.getKeyType(), typesBelongingCompositeTypeForKeyType,
+				columnFamily.getComparatorType(), typesBelongingCompositeTypeForComparatorType, columnFamily.getSubComparatorType(),
+				columnFamily.getDefaultColumnValueType()));
 
-        return columnFamily;
-    }
+		return columnFamily;
+	}
 
-    private List<ColumnMetadataModel> mapXmlColumsMetadataToColumnsMetadata(
-            List<ColumnMetadata> xmlColumnsMetadata, ComparatorType comparatorType, GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
+	private List<ColumnMetadataModel> mapXmlColumsMetadataToColumnsMetadata(List<ColumnMetadata> xmlColumnsMetadata, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
 
-        ArrayList<ColumnMetadataModel> columnsMetadata = new ArrayList<ColumnMetadataModel>();
+		ArrayList<ColumnMetadataModel> columnsMetadata = new ArrayList<ColumnMetadataModel>();
 
-        for (org.cassandraunit.dataset.xml.ColumnMetadata xmlColumnMetadata : xmlColumnsMetadata) {
-            columnsMetadata.add(mapXmlColumnMetadataToColumMetadataModel(xmlColumnMetadata, comparatorType, typesBelongingCompositeTypeForComparatorType));
-        }
+		for (org.cassandraunit.dataset.xml.ColumnMetadata xmlColumnMetadata : xmlColumnsMetadata) {
+			columnsMetadata.add(mapXmlColumnMetadataToColumMetadataModel(xmlColumnMetadata, comparatorType, typesBelongingCompositeTypeForComparatorType));
+		}
 
-        return columnsMetadata;
-    }
+		return columnsMetadata;
+	}
 
-    private ColumnMetadataModel mapXmlColumnMetadataToColumMetadataModel(
-            ColumnMetadata xmlColumnMetadata, ComparatorType comparatorType, GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
-        ColumnMetadataModel columnMetadata = new ColumnMetadataModel();
-        columnMetadata.setColumnName(TypeExtractor.constructGenericType(xmlColumnMetadata.getName(), comparatorType, typesBelongingCompositeTypeForComparatorType));
-        columnMetadata
-                .setValidationClass(ComparatorType.getByClassName(xmlColumnMetadata.getValidationClass().value()));
-        if (xmlColumnMetadata.getIndexType() != null) {
-            columnMetadata.setColumnIndexType(ColumnIndexType.valueOf(xmlColumnMetadata.getIndexType().value()));
-        }
+	private ColumnMetadataModel mapXmlColumnMetadataToColumMetadataModel(ColumnMetadata xmlColumnMetadata, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType) {
+		ColumnMetadataModel columnMetadata = new ColumnMetadataModel();
+		columnMetadata.setColumnName(TypeExtractor.constructGenericType(xmlColumnMetadata.getName(), comparatorType,
+				typesBelongingCompositeTypeForComparatorType));
+		columnMetadata.setValidationClass(ComparatorType.getByClassName(xmlColumnMetadata.getValidationClass().value()));
+		if (xmlColumnMetadata.getIndexType() != null) {
+			columnMetadata.setColumnIndexType(ColumnIndexType.valueOf(xmlColumnMetadata.getIndexType().value()));
+		}
 
-        columnMetadata.setIndexName(xmlColumnMetadata.getIndexName());
+		columnMetadata.setIndexName(xmlColumnMetadata.getIndexName());
 
-        return columnMetadata;
-    }
+		return columnMetadata;
+	}
 
-    private List<RowModel> mapXmlRowsToRowsModel(org.cassandraunit.dataset.xml.ColumnFamily xmlColumnFamily,
-                                                 ComparatorType keyType, GenericTypeEnum[] typesBelongingCompositeTypeForKeyType,
-                                                 ComparatorType comparatorType, GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType,
-                                                 ComparatorType subcomparatorType, ComparatorType defaultColumnValueType) {
-        List<RowModel> rowsModel = new ArrayList<RowModel>();
-        List<ColumnMetadata> columnMetaData = new ArrayList<ColumnMetadata>();
-        if (xmlColumnFamily.getColumnMetadata() != null) {
-            columnMetaData = xmlColumnFamily.getColumnMetadata();
-        }
-        for (Row rowType : xmlColumnFamily.getRow()) {
-            rowsModel.add(mapsXmlRowToRowModel(columnMetaData, rowType, keyType, typesBelongingCompositeTypeForKeyType, comparatorType,
-                    typesBelongingCompositeTypeForComparatorType, subcomparatorType, defaultColumnValueType));
-        }
-        return rowsModel;
-    }
+	private List<RowModel> mapXmlRowsToRowsModel(org.cassandraunit.dataset.xml.ColumnFamily xmlColumnFamily, ComparatorType keyType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForKeyType, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType subcomparatorType, ComparatorType defaultColumnValueType) {
+		List<RowModel> rowsModel = new ArrayList<RowModel>();
+		List<ColumnMetadata> columnMetaData = new ArrayList<ColumnMetadata>();
+		if (xmlColumnFamily.getColumnMetadata() != null) {
+			columnMetaData = xmlColumnFamily.getColumnMetadata();
+		}
+		for (Row rowType : xmlColumnFamily.getRow()) {
+			rowsModel.add(mapsXmlRowToRowModel(columnMetaData, rowType, keyType, typesBelongingCompositeTypeForKeyType, comparatorType,
+					typesBelongingCompositeTypeForComparatorType, subcomparatorType, defaultColumnValueType));
+		}
+		return rowsModel;
+	}
 
-    private RowModel mapsXmlRowToRowModel(List<ColumnMetadata> columnMetaData, Row xmlRow, ComparatorType keyType,
-                                          GenericTypeEnum[] typesBelongingCompositeTypeForKeyType, ComparatorType comparatorType,
-                                          GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType subComparatorType,
-                                          ComparatorType defaultColumnValueType) {
-        RowModel row = new RowModel();
+	private RowModel mapsXmlRowToRowModel(List<ColumnMetadata> columnMetaData, Row xmlRow, ComparatorType keyType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForKeyType, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
+		RowModel row = new RowModel();
 
-        row.setKey(TypeExtractor.constructGenericType(xmlRow.getKey(), keyType, typesBelongingCompositeTypeForKeyType));
+		row.setKey(TypeExtractor.constructGenericType(xmlRow.getKey(), keyType, typesBelongingCompositeTypeForKeyType));
 
-        row.setColumns(mapXmlColumnsToColumnsModel(columnMetaData, xmlRow.getColumn(), comparatorType,
-                typesBelongingCompositeTypeForComparatorType, defaultColumnValueType));
-        row.setSuperColumns(mapXmlSuperColumnsToSuperColumnsModel(columnMetaData, xmlRow.getSuperColumn(), comparatorType,
-                subComparatorType, defaultColumnValueType));
-        return row;
-    }
+		row.setColumns(mapXmlColumnsToColumnsModel(columnMetaData, xmlRow.getColumn(), comparatorType, typesBelongingCompositeTypeForComparatorType,
+				defaultColumnValueType));
+		row.setSuperColumns(mapXmlSuperColumnsToSuperColumnsModel(columnMetaData, xmlRow.getSuperColumn(), comparatorType, subComparatorType,
+				defaultColumnValueType));
+		return row;
+	}
 
-    /**
-     * map an xml super columns to a super columns
-     *
-     * @param xmlSuperColumns   xml super columns
-     * @param subComparatorType
-     * @param comparatorType
-     * @return super columns
-     */
-    private List<SuperColumnModel> mapXmlSuperColumnsToSuperColumnsModel(List<ColumnMetadata> columnMetaData, List<SuperColumn> xmlSuperColumns,
-                                                                         ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
-        List<SuperColumnModel> columnsModel = new ArrayList<SuperColumnModel>();
-        for (SuperColumn xmlSuperColumnType : xmlSuperColumns) {
-            columnsModel.add(mapXmlSuperColumnToSuperColumnModel(columnMetaData, xmlSuperColumnType, comparatorType, subComparatorType,
-                    defaultColumnValueType));
-        }
+	/**
+	 * map an xml super columns to a super columns
+	 * 
+	 * @param xmlSuperColumns
+	 *            xml super columns
+	 * @param subComparatorType
+	 * @param comparatorType
+	 * @return super columns
+	 */
+	private List<SuperColumnModel> mapXmlSuperColumnsToSuperColumnsModel(List<ColumnMetadata> columnMetaData, List<SuperColumn> xmlSuperColumns,
+			ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
+		List<SuperColumnModel> columnsModel = new ArrayList<SuperColumnModel>();
+		for (SuperColumn xmlSuperColumnType : xmlSuperColumns) {
+			columnsModel
+					.add(mapXmlSuperColumnToSuperColumnModel(columnMetaData, xmlSuperColumnType, comparatorType, subComparatorType, defaultColumnValueType));
+		}
 
-        return columnsModel;
-    }
+		return columnsModel;
+	}
 
-    /**
-     * map an xml super colmun to a super column
-     *
-     * @param xmlSuperColumn    xml super column
-     * @param subComparatorType
-     * @param comparatorType
-     * @return supercolumn
-     */
-    private SuperColumnModel mapXmlSuperColumnToSuperColumnModel(List<ColumnMetadata> columnMetaData, SuperColumn xmlSuperColumn,
-                                                                 ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
-        SuperColumnModel superColumnModel = new SuperColumnModel();
+	/**
+	 * map an xml super colmun to a super column
+	 * 
+	 * @param xmlSuperColumn
+	 *            xml super column
+	 * @param subComparatorType
+	 * @param comparatorType
+	 * @return supercolumn
+	 */
+	private SuperColumnModel mapXmlSuperColumnToSuperColumnModel(List<ColumnMetadata> columnMetaData, SuperColumn xmlSuperColumn,
+			ComparatorType comparatorType, ComparatorType subComparatorType, ComparatorType defaultColumnValueType) {
+		SuperColumnModel superColumnModel = new SuperColumnModel();
 
-        superColumnModel.setName(new GenericType(xmlSuperColumn.getName(), GenericTypeEnum.fromValue(comparatorType
-                .getTypeName())));
+		superColumnModel.setName(new GenericType(xmlSuperColumn.getName(), GenericTypeEnum.fromValue(comparatorType.getTypeName())));
 
-        superColumnModel.setColumns(mapXmlColumnsToColumnsModel(columnMetaData, xmlSuperColumn.getColumn(), subComparatorType, null,
-                defaultColumnValueType));
-        return superColumnModel;
-    }
+		superColumnModel.setColumns(mapXmlColumnsToColumnsModel(columnMetaData, xmlSuperColumn.getColumn(), subComparatorType, null, defaultColumnValueType));
+		return superColumnModel;
+	}
 
-    /**
-     * map an xml column to a column
-     *
-     * @param xmlColumn xml column
-     * @param typesBelongingCompositeTypeForComparatorType
-     *
-     * @return column
-     */
-    private ColumnModel mapXmlColumnToColumnModel(ColumnMetadata metaData, Column xmlColumn, ComparatorType comparatorType,
-                                                  GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType defaultColumnValueType) {
-        ColumnModel columnModel = new ColumnModel();
+	/**
+	 * map an xml column to a column
+	 * 
+	 * @param xmlColumn
+	 *            xml column
+	 * @param typesBelongingCompositeTypeForComparatorType
+	 * 
+	 * @return column
+	 */
+	private ColumnModel mapXmlColumnToColumnModel(ColumnMetadata metaData, Column xmlColumn, ComparatorType comparatorType,
+			GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType defaultColumnValueType) {
+		ColumnModel columnModel = new ColumnModel();
 
-        if (comparatorType == null) {
-            columnModel.setName(new GenericType(xmlColumn.getName(), GenericTypeEnum.BYTES_TYPE));
-        } else if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
-            /* composite type */
-            try {
-                columnModel.setName(new GenericType(StringUtils.split(xmlColumn.getName(), ":"),
-                        typesBelongingCompositeTypeForComparatorType));
-            } catch (IllegalArgumentException e) {
-                throw new ParseException(xmlColumn.getName()
-                        + " doesn't fit with the schema declaration of your composite type");
-            }
-        } else {
-            /* simple type */
-            columnModel.setName(new GenericType(xmlColumn.getName(), GenericTypeEnum.fromValue(comparatorType
-                    .getTypeName())));
-        }
+		if (comparatorType == null) {
+			columnModel.setName(new GenericType(xmlColumn.getName(), GenericTypeEnum.BYTES_TYPE));
+		} else if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
+			/* composite type */
+			try {
+				columnModel.setName(new GenericType(StringUtils.split(xmlColumn.getName(), ":"), typesBelongingCompositeTypeForComparatorType));
+			} catch (IllegalArgumentException e) {
+				throw new ParseException(xmlColumn.getName() + " doesn't fit with the schema declaration of your composite type");
+			}
+		} else {
+			/* simple type */
+			columnModel.setName(new GenericType(xmlColumn.getName(), GenericTypeEnum.fromValue(comparatorType.getTypeName())));
+		}
 
-        if (defaultColumnValueType != null
-                && ComparatorType.COUNTERTYPE.getClassName().equals(defaultColumnValueType.getClassName())
-                && TypeExtractor.containFunctions(xmlColumn.getValue())) {
-            throw new ParseException("Impossible to override Column value into a Counter column family");
-        }
+		if (defaultColumnValueType != null && ComparatorType.COUNTERTYPE.getClassName().equals(defaultColumnValueType.getClassName())
+				&& TypeExtractor.containFunctions(xmlColumn.getValue())) {
+			throw new ParseException("Impossible to override Column value into a Counter column family");
+		}
 
-        GenericType columnValue = null;
-        if (xmlColumn.getValue() != null) {
-            if (metaData != null && !TypeExtractor.containFunctions(xmlColumn.getValue())) {
-                GenericTypeEnum genTypeEnum = GenericTypeEnum.valueOf(metaData.getValidationClass().name());
-                columnValue = new GenericType(xmlColumn.getValue(), genTypeEnum);
-            } else {
-                columnValue = TypeExtractor.extract(xmlColumn.getValue(), defaultColumnValueType);
-            }
-        }
-        columnModel.setValue(columnValue);
+		GenericType columnValue = null;
+		if (xmlColumn.getValue() != null) {
+			if (metaData != null && !TypeExtractor.containFunctions(xmlColumn.getValue())) {
+				GenericTypeEnum genTypeEnum = GenericTypeEnum.valueOf(metaData.getValidationClass().name());
+				columnValue = new GenericType(xmlColumn.getValue(), genTypeEnum);
+			} else {
+				columnValue = TypeExtractor.extract(xmlColumn.getValue(), defaultColumnValueType);
+			}
+		}
+		columnModel.setValue(columnValue);
 
-        String timestamp = xmlColumn.getTimestamp();
-        if (timestamp != null) {
-            columnModel.setTimestamp(Long.valueOf(timestamp));
-        } else {
-            columnModel.setTimestamp(null);
-        }
+		String timestamp = xmlColumn.getTimestamp();
+		if (timestamp != null) {
+			columnModel.setTimestamp(Long.valueOf(timestamp));
+		} else {
+			columnModel.setTimestamp(null);
+		}
 
+		return columnModel;
+	}
 
-        return columnModel;
-    }
+	/**
+	 * map an xml columns to columns
+	 * 
+	 * @param xmlColumns
+	 *            xml column
+	 * @param typesBelongingCompositeTypeForComparatorType
+	 * 
+	 * @return columns
+	 */
+	private List<ColumnModel> mapXmlColumnsToColumnsModel(List<ColumnMetadata> columnMetaData, List<Column> xmlColumns,
+			ComparatorType columnNameComparatorType, GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType, ComparatorType defaultColumnValueType) {
+		List<ColumnModel> columnsModel = new ArrayList<ColumnModel>();
 
-    /**
-     * map an xml columns to columns
-     *
-     * @param xmlColumns xml column
-     * @param typesBelongingCompositeTypeForComparatorType
-     *
-     * @return columns
-     */
-    private List<ColumnModel> mapXmlColumnsToColumnsModel(List<ColumnMetadata> columnMetaData, List<Column> xmlColumns,
-                                                          ComparatorType columnNameComparatorType, GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType,
-                                                          ComparatorType defaultColumnValueType) {
-        List<ColumnModel> columnsModel = new ArrayList<ColumnModel>();
+		for (Column xmlColumn : xmlColumns) {
+			ColumnMetadata assocMetaData = null;
+			for (ColumnMetadata tmpColumnMetaData : columnMetaData) {
+				if (tmpColumnMetaData.getName().equals(xmlColumn.getName())) {
+					assocMetaData = tmpColumnMetaData;
+				}
+			}
+			columnsModel.add(mapXmlColumnToColumnModel(assocMetaData, xmlColumn, columnNameComparatorType, typesBelongingCompositeTypeForComparatorType,
+					defaultColumnValueType));
+		}
+		return columnsModel;
+	}
 
-        for (Column xmlColumn : xmlColumns) {
-            ColumnMetadata assocMetaData = null;
-            for (ColumnMetadata tmpColumnMetaData : columnMetaData) {
-                if (tmpColumnMetaData.getName().equals(xmlColumn.getName())) {
-                    assocMetaData = tmpColumnMetaData;
-                }
-            }
-            columnsModel.add(mapXmlColumnToColumnModel(assocMetaData, xmlColumn, columnNameComparatorType,
-                    typesBelongingCompositeTypeForComparatorType, defaultColumnValueType));
-        }
-        return columnsModel;
-    }
+	@Override
+	public KeyspaceModel getKeyspace() {
+		if (keyspace == null) {
+			org.cassandraunit.dataset.xml.Keyspace xmlKeyspace = getXmlKeyspace();
+			mapXmlKeyspaceToModel(xmlKeyspace);
+		}
+		return keyspace;
+	}
 
-    @Override
-    public KeyspaceModel getKeyspace() {
-        if (keyspace == null) {
-            org.cassandraunit.dataset.xml.Keyspace xmlKeyspace = getXmlKeyspace();
-            mapXmlKeyspaceToModel(xmlKeyspace);
-        }
-        return keyspace;
-    }
-
-    @Override
-    public List<ColumnFamilyModel> getColumnFamilies() {
-        if (keyspace == null) {
-            getKeyspace();
-        }
-        return keyspace.getColumnFamilies();
-    }
+	@Override
+	public List<ColumnFamilyModel> getColumnFamilies() {
+		if (keyspace == null) {
+			getKeyspace();
+		}
+		return keyspace.getColumnFamilies();
+	}
 
 }

--- a/src/main/java/org/cassandraunit/utils/ComparatorTypeHelper.java
+++ b/src/main/java/org/cassandraunit/utils/ComparatorTypeHelper.java
@@ -1,76 +1,122 @@
 package org.cassandraunit.utils;
 
 import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import org.apache.commons.lang.StringUtils;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.dataset.commons.ParsedDataType;
 import org.cassandraunit.type.GenericTypeEnum;
 
+/**
+ * @author Jeremy Sevellec
+ * @author Marc Carre
+ */
 public class ComparatorTypeHelper {
 
-    public static ComparatorType verifyAndExtract(String comparatorType) {
+	private static final String COMPOSITE_TYPE = "CompositeType";
 
-        final String COMPOSITE_TYPE = "CompositeType";
-        if (StringUtils.startsWith(comparatorType, COMPOSITE_TYPE)) {
-            boolean error = false;
-            /* CompositeType is defined */
-            String aliasType = StringUtils.removeStart(comparatorType, COMPOSITE_TYPE);
-            if (notStardOrNotEndWithParenthesis(aliasType)) {
-                error = true;
-            } else {
-                String aliasTypeWithoutParenthesis = StringUtils
-                        .removeStart(StringUtils.removeEnd(aliasType, ")"), "(");
-                String[] types = StringUtils.split(aliasTypeWithoutParenthesis, ",");
-                if (typesNotNullAndNotEmpty(types)) {
-                    error = true;
-                } else {
-                    /* has to be a known type */
-                    try {
-                        for (int i = 0; i < types.length; i++) {
-                            ParsedDataType.valueOf(types[i]);
-                        }
-                    } catch (IllegalArgumentException e) {
-                        error = true;
-                    }
-                }
-            }
+	public static ComparatorType verifyAndExtract(String comparatorType) {
+		if (isCompositeType(comparatorType)) {
+			return parseCompositeComparatorType(comparatorType);
+		} else {
+			return parseSimpleComparatorType(comparatorType);
+		}
+	}
 
-            if (error) {
-                throw new ParseException("CompositeType has to be like that : CompositeType(<type>,...,<type>)");
-            } else {
-                return ComparatorType.COMPOSITETYPE;
-            }
-        } else {
-            /* standard Type */
-            try {
-                ParsedDataType.valueOf(comparatorType);
-                return ComparatorType.getByClassName(comparatorType);
-            } catch (IllegalArgumentException e) {
-                throw new ParseException("ComparatorType value is not allowed");
-            }
-        }
+	private static boolean isCompositeType(String comparatorType) {
+		return StringUtils.startsWith(comparatorType, COMPOSITE_TYPE);
+	}
 
-    }
+	private static ComparatorType parseCompositeComparatorType(String comparatorType) {
+		String compositeType = removePrependingCompositeType(comparatorType);
 
-    private static boolean typesNotNullAndNotEmpty(String[] types) {
-        return (types == null) || (types.length == 0);
-    }
+		if (!hasParenthesisForComponentTypes(compositeType)) {
+			throw new ParseException("[" + comparatorType + "] must contain types wrapped within parenthesis, like: CompositeType(<type>,...,<type>).");
+		}
 
-    private static boolean notStardOrNotEndWithParenthesis(String aliasType) {
-        return !StringUtils.startsWith(aliasType, "(") || !StringUtils.endsWith(aliasType, ")");
-    }
+		String[] types = extractComponentTypes(compositeType);
 
-    public static GenericTypeEnum[] extractGenericTypesFromTypeAlias(String comparatorTypeAlias) {
-        String aliasTypeWithoutParenthesis = StringUtils.removeStart(StringUtils.removeEnd(comparatorTypeAlias, ")"),
-                "(");
-        String[] types = StringUtils.split(aliasTypeWithoutParenthesis, ",");
+		if (areTypesNullOrEmpty(types)) {
+			throw new ParseException("[" + comparatorType + "] must contain non-empty types, like: CompositeType(<type>,...,<type>).");
+		}
 
-        GenericTypeEnum[] genericTypesEnum = new GenericTypeEnum[types.length];
+		for (String type : types) {
+			parseComponentType(comparatorType, type);
+		}
 
-        for (int i = 0; i < types.length; i++) {
-            genericTypesEnum[i] = GenericTypeEnum.fromValue(types[i]);
-        }
+		return ComparatorType.COMPOSITETYPE;
+	}
 
-        return genericTypesEnum;
-    }
+	private static String removePrependingCompositeType(String comparatorType) {
+		return StringUtils.removeStart(comparatorType, COMPOSITE_TYPE);
+	}
+
+	private static boolean hasParenthesisForComponentTypes(String types) {
+		return StringUtils.startsWith(types, "(") && StringUtils.endsWith(types, ")");
+	}
+
+	private static String[] extractComponentTypes(String compositeType) {
+		String compositeTypeWithoutParenthesis = removeWrappingParenthesis(compositeType);
+		return StringUtils.split(compositeTypeWithoutParenthesis, ",");
+	}
+
+	private static String removeWrappingParenthesis(String aliasType) {
+		return StringUtils.removeStart(StringUtils.removeEnd(aliasType, ")"), "(");
+	}
+
+	private static boolean areTypesNullOrEmpty(String[] types) {
+		if (isNullOrEmpty(types))
+			return true;
+
+		for (String type : types)
+			if (isNullOrEmpty(type))
+				return true;
+
+		return false;
+	}
+
+	private static boolean isNullOrEmpty(String[] types) {
+		return (types == null) || (types.length == 0);
+	}
+
+	private static boolean isNullOrEmpty(String type) {
+		return (type == null) || (type.length() == 0);
+	}
+
+	private static void parseComponentType(String comparatorType, String type) {
+		try {
+			// Component types may take values like "IntegerType" or "TimeUUID(reversed=true)" or even "LongType(reversed=false)".
+			String cleanType = removeReversedQualifierIfPresent(type);
+			ParsedDataType.valueOf(cleanType);
+		} catch (IllegalArgumentException e) {
+			throw new ParseException("[" + comparatorType + "] contains an invalid 'component' type: [" + type + "].");
+		}
+	}
+
+	private static String removeReversedQualifierIfPresent(String type) {
+		return StringUtils.removeEndIgnoreCase(StringUtils.removeEndIgnoreCase(type, "(reversed=true)"), "(reversed=false)");
+	}
+
+	private static ComparatorType parseSimpleComparatorType(String type) {
+		try {
+			// ComparatorTypes may take values like "IntegerType" or "TimeUUID(reversed=true)" or even "LongType(reversed=false)".
+			String cleanType = removeReversedQualifierIfPresent(type);
+			ParsedDataType.valueOf(cleanType);
+			return ComparatorType.getByClassName(cleanType);
+		} catch (IllegalArgumentException e) {
+			throw new ParseException("ComparatorType [" + type + "] is invalid.");
+		}
+	}
+
+	public static GenericTypeEnum[] extractGenericTypesFromTypeAlias(String comparatorType) {
+		String[] types = extractComponentTypes(comparatorType);
+		GenericTypeEnum[] genericTypesEnum = new GenericTypeEnum[types.length];
+
+		for (int i = 0; i < types.length; i++) {
+			String cleanType = removeReversedQualifierIfPresent(types[i]);
+			genericTypesEnum[i] = GenericTypeEnum.fromValue(cleanType);
+		}
+
+		return genericTypesEnum;
+	}
 }

--- a/src/test/java/org/cassandraunit/DataLoaderTest.java
+++ b/src/test/java/org/cassandraunit/DataLoaderTest.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Maps;
 import me.prettyprint.cassandra.serializers.BytesArraySerializer;
 import me.prettyprint.cassandra.serializers.CompositeSerializer;
 import me.prettyprint.cassandra.serializers.IntegerSerializer;
@@ -24,7 +22,6 @@ import me.prettyprint.cassandra.serializers.StringSerializer;
 import me.prettyprint.cassandra.serializers.UUIDSerializer;
 import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.Keyspace;
-import me.prettyprint.hector.api.beans.ColumnSlice;
 import me.prettyprint.hector.api.beans.Composite;
 import me.prettyprint.hector.api.beans.CounterSlice;
 import me.prettyprint.hector.api.beans.CounterSuperSlice;
@@ -34,7 +31,11 @@ import me.prettyprint.hector.api.beans.OrderedRows;
 import me.prettyprint.hector.api.beans.OrderedSuperRows;
 import me.prettyprint.hector.api.beans.Row;
 import me.prettyprint.hector.api.beans.SuperRow;
-import me.prettyprint.hector.api.ddl.*;
+import me.prettyprint.hector.api.ddl.ColumnDefinition;
+import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
+import me.prettyprint.hector.api.ddl.ColumnIndexType;
+import me.prettyprint.hector.api.ddl.ColumnType;
+import me.prettyprint.hector.api.ddl.ComparatorType;
 import me.prettyprint.hector.api.exceptions.HInvalidRequestException;
 import me.prettyprint.hector.api.exceptions.HectorException;
 import me.prettyprint.hector.api.factory.HFactory;
@@ -42,12 +43,10 @@ import me.prettyprint.hector.api.query.QueryResult;
 import me.prettyprint.hector.api.query.RangeSlicesQuery;
 import me.prettyprint.hector.api.query.RangeSuperSlicesQuery;
 import me.prettyprint.hector.api.query.SliceCounterQuery;
-import me.prettyprint.hector.api.query.SliceQuery;
 import me.prettyprint.hector.api.query.SuperSliceCounterQuery;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.http.annotation.Immutable;
 import org.cassandraunit.model.StrategyModel;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.cassandraunit.utils.MockDataSetHelper;
@@ -55,6 +54,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.collect.Maps;
 
 /**
  * 
@@ -106,8 +107,7 @@ public class DataLoaderTest {
 		Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 		assertThat(cluster.describeKeyspace("beautifulKeyspaceName"), notNullValue());
 		assertThat(cluster.describeKeyspace("beautifulKeyspaceName").getReplicationFactor(), is(1));
-		assertThat(cluster.describeKeyspace("beautifulKeyspaceName").getStrategyClass(),
-				is("org.apache.cassandra.locator.SimpleStrategy"));
+		assertThat(cluster.describeKeyspace("beautifulKeyspaceName").getStrategyClass(), is("org.apache.cassandra.locator.SimpleStrategy"));
 
 	}
 
@@ -123,8 +123,7 @@ public class DataLoaderTest {
 		Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 		assertThat(cluster.describeKeyspace("keyspace"), notNullValue());
 		assertThat(cluster.describeKeyspace("keyspace").getCfDefs().get(0).getName(), is("columnFamily"));
-		assertThat(cluster.describeKeyspace("keyspace").getCfDefs().get(0).getDefaultValidationClass(),
-				is(ComparatorType.LONGTYPE.getClassName()));
+		assertThat(cluster.describeKeyspace("keyspace").getCfDefs().get(0).getDefaultValidationClass(), is(ComparatorType.LONGTYPE.getClassName()));
 	}
 
 	@Test
@@ -152,83 +151,64 @@ public class DataLoaderTest {
 		Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 		String keyspaceName = "otherKeyspaceName";
 		assertThat(cluster.describeKeyspace(keyspaceName), notNullValue());
-        List<ColumnFamilyDefinition> columnFamilyDefinitions = cluster.describeKeyspace(keyspaceName).getCfDefs();
-        assertThat(columnFamilyDefinitions, notNullValue());
+		List<ColumnFamilyDefinition> columnFamilyDefinitions = cluster.describeKeyspace(keyspaceName).getCfDefs();
+		assertThat(columnFamilyDefinitions, notNullValue());
 		assertThat(columnFamilyDefinitions.size(), is(5));
 
-        Map<String,ColumnFamilyDefinition> columnFamilyDefinitionsMap = Maps.uniqueIndex(columnFamilyDefinitions, new Function<ColumnFamilyDefinition, String>() {
-            @Override
-            public String apply(ColumnFamilyDefinition columnFamilyDefinition) {
-                return columnFamilyDefinition.getName();
-            }
-        });
+		Map<String, ColumnFamilyDefinition> columnFamilyDefinitionsMap = Maps.uniqueIndex(columnFamilyDefinitions,
+				new Function<ColumnFamilyDefinition, String>() {
+					@Override
+					public String apply(ColumnFamilyDefinition columnFamilyDefinition) {
+						return columnFamilyDefinition.getName();
+					}
+				});
 
-        ColumnFamilyDefinition beautifulColumnFamily = columnFamilyDefinitionsMap.get("beautifulColumnFamilyName");
-        assertThat(beautifulColumnFamily.getName(), is("beautifulColumnFamilyName"));
-		assertThat(beautifulColumnFamily.getKeyValidationClass(),
-                is(ComparatorType.TIMEUUIDTYPE.getClassName()));
+		ColumnFamilyDefinition beautifulColumnFamily = columnFamilyDefinitionsMap.get("beautifulColumnFamilyName");
+		assertThat(beautifulColumnFamily.getName(), is("beautifulColumnFamilyName"));
+		assertThat(beautifulColumnFamily.getKeyValidationClass(), is(ComparatorType.TIMEUUIDTYPE.getClassName()));
 		assertThat(beautifulColumnFamily.getColumnType(), is(ColumnType.SUPER));
-		assertThat(beautifulColumnFamily.getComparatorType().getClassName(),
-				is(ComparatorType.UTF8TYPE.getClassName()));
-		assertThat(beautifulColumnFamily.getSubComparatorType().getClassName(),
-				is(ComparatorType.LONGTYPE.getClassName()));
-        assertThat(beautifulColumnFamily.getComment(), is("amazing comment"));
-        assertThat(beautifulColumnFamily.getCompactionStrategy(),is("org.apache.cassandra.db.compaction.LeveledCompactionStrategy"));
-        assertThat(beautifulColumnFamily.getCompactionStrategyOptions().get("sstable_size_in_mb"),is("10"));
-        assertThat(beautifulColumnFamily.getGcGraceSeconds(),is(9999));
-        assertThat(beautifulColumnFamily.getMaxCompactionThreshold(),is(31));
-        assertThat(beautifulColumnFamily.getMinCompactionThreshold(),is(3));
-        assertThat(beautifulColumnFamily.getReadRepairChance(),is(0.1d));
-        assertThat(beautifulColumnFamily.isReplicateOnWrite(),is(false));
+		assertThat(beautifulColumnFamily.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
+		assertThat(beautifulColumnFamily.getSubComparatorType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
+		assertThat(beautifulColumnFamily.getComment(), is("amazing comment"));
+		assertThat(beautifulColumnFamily.getCompactionStrategy(), is("org.apache.cassandra.db.compaction.LeveledCompactionStrategy"));
+		assertThat(beautifulColumnFamily.getCompactionStrategyOptions().get("sstable_size_in_mb"), is("10"));
+		assertThat(beautifulColumnFamily.getGcGraceSeconds(), is(9999));
+		assertThat(beautifulColumnFamily.getMaxCompactionThreshold(), is(31));
+		assertThat(beautifulColumnFamily.getMinCompactionThreshold(), is(3));
+		assertThat(beautifulColumnFamily.getReadRepairChance(), is(0.1d));
+		assertThat(beautifulColumnFamily.isReplicateOnWrite(), is(false));
 
-
-        ColumnFamilyDefinition amazingColumnFamily = columnFamilyDefinitionsMap.get("amazingColumnFamilyName");
-        assertThat(amazingColumnFamily.getName(), is("amazingColumnFamilyName"));
-		assertThat(amazingColumnFamily.getKeyValidationClass(),
-				is(ComparatorType.UTF8TYPE.getClassName()));
+		ColumnFamilyDefinition amazingColumnFamily = columnFamilyDefinitionsMap.get("amazingColumnFamilyName");
+		assertThat(amazingColumnFamily.getName(), is("amazingColumnFamilyName"));
+		assertThat(amazingColumnFamily.getKeyValidationClass(), is(ComparatorType.UTF8TYPE.getClassName()));
 		assertThat(amazingColumnFamily.getColumnType(), is(ColumnType.STANDARD));
-		assertThat(amazingColumnFamily.getComparatorType().getClassName(),
-				is(ComparatorType.UTF8TYPE.getClassName()));
+		assertThat(amazingColumnFamily.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
 
-
-        ColumnFamilyDefinition columnFamilyWithSecondaryIndex = columnFamilyDefinitionsMap.get("columnFamilyWithSecondaryIndex");
-        assertThat(columnFamilyWithSecondaryIndex.getName(), is("columnFamilyWithSecondaryIndex"));
+		ColumnFamilyDefinition columnFamilyWithSecondaryIndex = columnFamilyDefinitionsMap.get("columnFamilyWithSecondaryIndex");
+		assertThat(columnFamilyWithSecondaryIndex.getName(), is("columnFamilyWithSecondaryIndex"));
 		assertThat(columnFamilyWithSecondaryIndex.getColumnMetadata(), notNullValue());
-        ColumnDefinition columnDefinition = columnFamilyWithSecondaryIndex.getColumnMetadata().get(0);
-        assertThat(columnDefinition, notNullValue());
-		assertThat(columnDefinition.getName(),
-				is(ByteBuffer.wrap("columnWithSecondaryIndexAndValidationClassAsLongType".getBytes(Charsets.UTF_8))));
-		assertThat(columnDefinition.getIndexName(),
-				is("columnWithSecondaryIndexAndValidationClassAsLongType"));
-		assertThat(columnDefinition.getIndexType(),
-				is(ColumnIndexType.KEYS));
-		assertThat(columnDefinition
-				.getValidationClass(), is(ComparatorType.LONGTYPE.getClassName()));
+		ColumnDefinition columnDefinition = columnFamilyWithSecondaryIndex.getColumnMetadata().get(0);
+		assertThat(columnDefinition, notNullValue());
+		assertThat(columnDefinition.getName(), is(ByteBuffer.wrap("columnWithSecondaryIndexAndValidationClassAsLongType".getBytes(Charsets.UTF_8))));
+		assertThat(columnDefinition.getIndexName(), is("columnWithSecondaryIndexAndValidationClassAsLongType"));
+		assertThat(columnDefinition.getIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(columnDefinition.getValidationClass(), is(ComparatorType.LONGTYPE.getClassName()));
 
+		ColumnFamilyDefinition columnFamilyWithSecondaryIndexAndIndexName = columnFamilyDefinitionsMap.get("columnFamilyWithSecondaryIndexAndIndexName");
+		ColumnDefinition columnDefinition1 = columnFamilyWithSecondaryIndexAndIndexName.getColumnMetadata().get(0);
+		assertThat(columnDefinition1, notNullValue());
+		assertThat(columnDefinition1.getIndexName(), is("columnWithSecondaryIndexHaveIndexNameAndValidationClassAsUTF8Type"));
+		assertThat(columnDefinition1.getName(), is(ByteBuffer.wrap("columnWithSecondaryIndexAndValidationClassAsUTF8Type".getBytes(Charsets.UTF_8))));
+		assertThat(columnDefinition1.getIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(columnDefinition1.getValidationClass(), is(ComparatorType.UTF8TYPE.getClassName()));
 
-        ColumnFamilyDefinition columnFamilyWithSecondaryIndexAndIndexName = columnFamilyDefinitionsMap.get("columnFamilyWithSecondaryIndexAndIndexName");
-        ColumnDefinition columnDefinition1 = columnFamilyWithSecondaryIndexAndIndexName.getColumnMetadata().get(0);
-        assertThat(columnDefinition1, notNullValue());
-		assertThat(columnDefinition1.getIndexName(),
-				is("columnWithSecondaryIndexHaveIndexNameAndValidationClassAsUTF8Type"));
-		assertThat(columnDefinition1.getName(),
-				is(ByteBuffer.wrap("columnWithSecondaryIndexAndValidationClassAsUTF8Type".getBytes(Charsets.UTF_8))));
-		assertThat(columnDefinition1.getIndexType(),
-				is(ColumnIndexType.KEYS));
-		assertThat(columnDefinition1
-				.getValidationClass(), is(ComparatorType.UTF8TYPE.getClassName()));
-
-        ColumnFamilyDefinition columnFamilyWithColumnValidationClass = columnFamilyDefinitionsMap.get("columnFamilyWithColumnValidationClass");
-        ColumnDefinition columnDefinition2 = columnFamilyWithColumnValidationClass.getColumnMetadata().get(0);
-        assertThat(columnDefinition2, notNullValue());
-		assertThat(columnDefinition2.getName(),
-				is(ByteBuffer.wrap("columnWithValidationClassAsUTF8Type".getBytes(Charsets.UTF_8))));
-		assertThat(columnDefinition2.getIndexName(),
-				nullValue());
-		assertThat(columnDefinition2.getIndexType(),
-				nullValue());
-		assertThat(columnDefinition2
-				.getValidationClass(), is(ComparatorType.UTF8TYPE.getClassName()));
+		ColumnFamilyDefinition columnFamilyWithColumnValidationClass = columnFamilyDefinitionsMap.get("columnFamilyWithColumnValidationClass");
+		ColumnDefinition columnDefinition2 = columnFamilyWithColumnValidationClass.getColumnMetadata().get(0);
+		assertThat(columnDefinition2, notNullValue());
+		assertThat(columnDefinition2.getName(), is(ByteBuffer.wrap("columnWithValidationClassAsUTF8Type".getBytes(Charsets.UTF_8))));
+		assertThat(columnDefinition2.getIndexName(), nullValue());
+		assertThat(columnDefinition2.getIndexType(), nullValue());
+		assertThat(columnDefinition2.getValidationClass(), is(ComparatorType.UTF8TYPE.getClassName()));
 
 	}
 
@@ -244,8 +224,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("beautifulKeyspaceName", cluster);
-			RangeSlicesQuery<byte[], byte[], byte[]> query = HFactory.createRangeSlicesQuery(keyspace,
-					BytesArraySerializer.get(), BytesArraySerializer.get(), BytesArraySerializer.get());
+			RangeSlicesQuery<byte[], byte[], byte[]> query = HFactory.createRangeSlicesQuery(keyspace, BytesArraySerializer.get(), BytesArraySerializer.get(),
+					BytesArraySerializer.get());
 			query.setColumnFamily("columnFamily1");
 			query.setRange(null, null, false, Integer.MAX_VALUE);
 			QueryResult<OrderedRows<byte[], byte[], byte[]>> result = query.execute();
@@ -278,9 +258,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("beautifulKeyspaceName", cluster);
-			RangeSuperSlicesQuery<byte[], byte[], byte[], byte[]> query = HFactory.createRangeSuperSlicesQuery(
-					keyspace, BytesArraySerializer.get(), BytesArraySerializer.get(), BytesArraySerializer.get(),
-					BytesArraySerializer.get());
+			RangeSuperSlicesQuery<byte[], byte[], byte[], byte[]> query = HFactory.createRangeSuperSlicesQuery(keyspace, BytesArraySerializer.get(),
+					BytesArraySerializer.get(), BytesArraySerializer.get(), BytesArraySerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName");
 			query.setRange(null, null, false, Integer.MAX_VALUE);
 			QueryResult<OrderedSuperRows<byte[], byte[], byte[], byte[]>> result = query.execute();
@@ -295,30 +274,22 @@ public class DataLoaderTest {
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns(), notNullValue());
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().size(), is(2));
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(0), notNullValue());
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getName(),
-					is(decodeHex("1110")));
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getValue(),
-					is(decodeHex("1110")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getName(), is(decodeHex("1110")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getValue(), is(decodeHex("1110")));
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(1), notNullValue());
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getName(),
-					is(decodeHex("1120")));
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getValue(),
-					is(decodeHex("1120")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getName(), is(decodeHex("1120")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getValue(), is(decodeHex("1120")));
 
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1), notNullValue());
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getName(), is(decodeHex("12")));
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns(), notNullValue());
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().size(), is(2));
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(0), notNullValue());
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(0).getName(),
-					is(decodeHex("1210")));
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(0).getValue(),
-					is(decodeHex("1210")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(0).getName(), is(decodeHex("1210")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(0).getValue(), is(decodeHex("1210")));
 			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(1), notNullValue());
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(1).getName(),
-					is(decodeHex("1220")));
-			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(1).getValue(),
-					is(decodeHex("1220")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(1).getName(), is(decodeHex("1220")));
+			assertThat(rows.get(0).getSuperSlice().getSuperColumns().get(1).getColumns().get(1).getValue(), is(decodeHex("1220")));
 
 			assertThat(rows.get(1).getKey(), is(decodeHex("02")));
 			assertThat(rows.get(1).getSuperSlice(), notNullValue());
@@ -329,15 +300,11 @@ public class DataLoaderTest {
 			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns(), notNullValue());
 			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().size(), is(2));
 			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(0), notNullValue());
-			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getName(),
-					is(decodeHex("2110")));
-			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getValue(),
-					is(decodeHex("2110")));
+			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getName(), is(decodeHex("2110")));
+			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(0).getValue(), is(decodeHex("2110")));
 			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(1), notNullValue());
-			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getName(),
-					is(decodeHex("2120")));
-			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getValue(),
-					is(decodeHex("2120")));
+			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getName(), is(decodeHex("2120")));
+			assertThat(rows.get(1).getSuperSlice().getSuperColumns().get(0).getColumns().get(1).getValue(), is(decodeHex("2120")));
 
 		} catch (HInvalidRequestException e) {
 			e.printStackTrace();
@@ -357,8 +324,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("otherKeyspaceName", cluster);
-			RangeSlicesQuery<UUID, String, byte[]> query = HFactory.createRangeSlicesQuery(keyspace,
-					UUIDSerializer.get(), StringSerializer.get(), BytesArraySerializer.get());
+			RangeSlicesQuery<UUID, String, byte[]> query = HFactory.createRangeSlicesQuery(keyspace, UUIDSerializer.get(), StringSerializer.get(),
+					BytesArraySerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName");
 			query.setRange(null, null, false, Integer.MAX_VALUE);
 			QueryResult<OrderedRows<UUID, String, byte[]>> result = query.execute();
@@ -399,8 +366,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("otherKeyspaceName", cluster);
-			RangeSlicesQuery<Long, Integer, byte[]> query = HFactory.createRangeSlicesQuery(keyspace,
-					LongSerializer.get(), IntegerSerializer.get(), BytesArraySerializer.get());
+			RangeSlicesQuery<Long, Integer, byte[]> query = HFactory.createRangeSlicesQuery(keyspace, LongSerializer.get(), IntegerSerializer.get(),
+					BytesArraySerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName2");
 			query.setRange(null, null, false, Integer.MAX_VALUE);
 			QueryResult<OrderedRows<Long, Integer, byte[]>> result = query.execute();
@@ -433,8 +400,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("otherKeyspaceName", cluster);
-			RangeSlicesQuery<UUID, UUID, byte[]> query = HFactory.createRangeSlicesQuery(keyspace,
-					UUIDSerializer.get(), UUIDSerializer.get(), BytesArraySerializer.get());
+			RangeSlicesQuery<UUID, UUID, byte[]> query = HFactory.createRangeSlicesQuery(keyspace, UUIDSerializer.get(), UUIDSerializer.get(),
+					BytesArraySerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName3");
 			query.setRange(null, null, false, Integer.MAX_VALUE);
 			QueryResult<OrderedRows<UUID, UUID, byte[]>> result = query.execute();
@@ -443,12 +410,10 @@ public class DataLoaderTest {
 			assertThat(rows.get(0).getKey(), is(UUID.fromString("13816710-1dd2-11b2-879a-782bcb80ff6a")));
 			assertThat(rows.get(0).getColumnSlice().getColumns().size(), is(2));
 			assertThat(rows.get(0).getColumnSlice().getColumns().get(0), notNullValue());
-			assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getName(),
-					is(UUID.fromString("13816710-1dd2-11b2-879a-782bcb80ff6a")));
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getName(), is(UUID.fromString("13816710-1dd2-11b2-879a-782bcb80ff6a")));
 			assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getValue(), is(decodeHex("11")));
 			assertThat(rows.get(0).getColumnSlice().getColumns().get(1), notNullValue());
-			assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getName(),
-					is(UUID.fromString("13818e20-1dd2-11b2-879a-782bcb80ff6a")));
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getName(), is(UUID.fromString("13818e20-1dd2-11b2-879a-782bcb80ff6a")));
 			assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getValue(), is(decodeHex("12")));
 
 		} catch (HInvalidRequestException e) {
@@ -469,8 +434,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("otherKeyspaceName", cluster);
-			RangeSlicesQuery<byte[], byte[], Long> query = HFactory.createRangeSlicesQuery(keyspace,
-					BytesArraySerializer.get(), BytesArraySerializer.get(), LongSerializer.get());
+			RangeSlicesQuery<byte[], byte[], Long> query = HFactory.createRangeSlicesQuery(keyspace, BytesArraySerializer.get(), BytesArraySerializer.get(),
+					LongSerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName4");
 			query.setRange(null, null, false, Integer.MAX_VALUE);
 			QueryResult<OrderedRows<byte[], byte[], Long>> result = query.execute();
@@ -503,8 +468,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("otherKeyspaceName", cluster);
-			RangeSlicesQuery<byte[], byte[], Long> query = HFactory.createRangeSlicesQuery(keyspace,
-					BytesArraySerializer.get(), BytesArraySerializer.get(), LongSerializer.get());
+			RangeSlicesQuery<byte[], byte[], Long> query = HFactory.createRangeSlicesQuery(keyspace, BytesArraySerializer.get(), BytesArraySerializer.get(),
+					LongSerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName5");
 			query.setRange(null, null, false, Integer.MAX_VALUE);
 			QueryResult<OrderedRows<byte[], byte[], Long>> result = query.execute();
@@ -551,8 +516,7 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("otherKeyspaceName", cluster);
-			SliceCounterQuery<Long, String> query = HFactory.createCounterSliceQuery(keyspace, LongSerializer.get(),
-					StringSerializer.get());
+			SliceCounterQuery<Long, String> query = HFactory.createCounterSliceQuery(keyspace, LongSerializer.get(), StringSerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName6");
 			query.setKey(10L);
 			query.setRange(null, null, false, 100);
@@ -584,8 +548,8 @@ public class DataLoaderTest {
 			/* verify */
 			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 			Keyspace keyspace = HFactory.createKeyspace("otherKeyspaceName", cluster);
-			SuperSliceCounterQuery<Long, String, String> query = HFactory.createSuperSliceCounterQuery(keyspace,
-					LongSerializer.get(), StringSerializer.get(), StringSerializer.get());
+			SuperSliceCounterQuery<Long, String, String> query = HFactory.createSuperSliceCounterQuery(keyspace, LongSerializer.get(), StringSerializer.get(),
+					StringSerializer.get());
 			query.setColumnFamily("beautifulColumnFamilyName7").setKey(10L);
 			query.setRange(null, null, false, 100);
 			QueryResult<CounterSuperSlice<String, String>> result = query.execute();
@@ -663,10 +627,93 @@ public class DataLoaderTest {
 		/* test */
 		Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
 		assertDefaultValuesSchemaExist(cluster);
-		assertThat(cluster.describeKeyspace("beautifulKeyspaceName").getStrategyClass(),
-				not("org.apache.cassandra.locator.NetworkTopologyStrategy"));
-		assertThat(cluster.describeKeyspace("beautifulKeyspaceName").getStrategyClass(),
-				is("org.apache.cassandra.locator.SimpleStrategy"));
+		assertThat(cluster.describeKeyspace("beautifulKeyspaceName").getStrategyClass(), not("org.apache.cassandra.locator.NetworkTopologyStrategy"));
+		assertThat(cluster.describeKeyspace("beautifulKeyspaceName").getStrategyClass(), is("org.apache.cassandra.locator.SimpleStrategy"));
 	}
 
+	@Test
+	public void shouldLoadDataWithReversedComparatorOnSimpleType() {
+		String clusterName = "TestCluster6";
+		String host = "localhost:9171";
+		DataLoader dataLoader = new DataLoader(clusterName, host);
+
+		try {
+			dataLoader.load(MockDataSetHelper.getMockDataSetWithReversedComparatorOnSimpleType());
+
+			/* verify */
+			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
+			Keyspace keyspace = HFactory.createKeyspace("reversedKeyspace", cluster);
+			RangeSlicesQuery<String, String, String> query = HFactory.createRangeSlicesQuery(keyspace, StringSerializer.get(), StringSerializer.get(),
+					StringSerializer.get());
+			query.setColumnFamily("columnFamilyWithReversedComparatorOnSimpleType");
+			query.setRange(null, null, false, Integer.MAX_VALUE);
+			QueryResult<OrderedRows<String, String, String>> result = query.execute();
+			List<Row<String, String, String>> rows = result.get().getList();
+
+			assertThat(rows.size(), is(1));
+			assertThat(rows.get(0).getKey(), is("row1"));
+			assertThat(rows.get(0).getColumnSlice().getColumns().size(), is(3));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(0), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getName(), is("c"));
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getValue(), is("c"));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(1), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getName(), is("b"));
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getValue(), is("b"));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(2), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(2).getName(), is("a"));
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(2).getValue(), is("a"));
+		} catch (HInvalidRequestException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void shouldLoadDataWithReversedComparatorOnCompositeTypes() {
+		String clusterName = "TestCluster6";
+		String host = "localhost:9171";
+		DataLoader dataLoader = new DataLoader(clusterName, host);
+
+		try {
+			dataLoader.load(MockDataSetHelper.getMockDataSetWithReversedComparatorOnCompositeTypes());
+
+			/* verify */
+			Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
+			Keyspace keyspace = HFactory.createKeyspace("reversedKeyspace", cluster);
+			RangeSlicesQuery<String, Composite, String> query = HFactory.createRangeSlicesQuery(keyspace, StringSerializer.get(), CompositeSerializer.get(),
+					StringSerializer.get());
+			query.setColumnFamily("columnFamilyWithReversedCompOnCompositeTypes");
+			query.setRange(null, null, false, Integer.MAX_VALUE);
+			QueryResult<OrderedRows<String, Composite, String>> result = query.execute();
+			List<Row<String, Composite, String>> rows = result.get().getList();
+
+			assertThat(rows.size(), is(1));
+			assertThat(rows.get(0).getKey(), is("row1"));
+			assertThat(rows.get(0).getColumnSlice().getColumns().size(), is(6));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(0), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getValue(), is("v6"));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(1), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getValue(), is("v5"));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(2), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(2).getValue(), is("v4"));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(3), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(3).getValue(), is("v3"));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(4), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(4).getValue(), is("v2"));
+
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(5), notNullValue());
+			assertThat(rows.get(0).getColumnSlice().getColumns().get(5).getValue(), is("v1"));
+		} catch (HInvalidRequestException e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
 }

--- a/src/test/java/org/cassandraunit/dataset/json/ClasspathJsonDataSetTest.java
+++ b/src/test/java/org/cassandraunit/dataset/json/ClasspathJsonDataSetTest.java
@@ -1,364 +1,441 @@
 package org.cassandraunit.dataset.json;
 
-import me.prettyprint.hector.api.ddl.ColumnIndexType;
-import me.prettyprint.hector.api.ddl.ColumnType;
-import me.prettyprint.hector.api.ddl.ComparatorType;
-import org.cassandraunit.dataset.DataSet;
-import org.cassandraunit.dataset.ParseException;
-import org.cassandraunit.model.*;
-import org.cassandraunit.type.GenericTypeEnum;
-import org.junit.Test;
+import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithCompositeTypeIsOk;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
-import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithCompositeTypeIsOk;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import me.prettyprint.hector.api.ddl.ColumnIndexType;
+import me.prettyprint.hector.api.ddl.ColumnType;
+import me.prettyprint.hector.api.ddl.ComparatorType;
+
+import org.cassandraunit.dataset.DataSet;
+import org.cassandraunit.dataset.ParseException;
+import org.cassandraunit.model.ColumnFamilyModel;
+import org.cassandraunit.model.ColumnMetadataModel;
+import org.cassandraunit.model.ColumnModel;
+import org.cassandraunit.model.KeyspaceModel;
+import org.cassandraunit.model.RowModel;
+import org.cassandraunit.model.StrategyModel;
+import org.cassandraunit.model.SuperColumnModel;
+import org.cassandraunit.type.GenericTypeEnum;
+import org.junit.Test;
 
 /**
  * @author Jeremy Sevellec
  */
 public class ClasspathJsonDataSetTest {
 
-    @Test
-    public void shouldGetAJsonDataSetStructure() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefaultValues.json");
-        assertThat(dataSet, notNullValue());
+	@Test
+	public void shouldGetAJsonDataSetStructure() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefaultValues.json");
+		assertThat(dataSet, notNullValue());
 
-        KeyspaceModel keyspace = dataSet.getKeyspace();
-        assertThat(keyspace, notNullValue());
-        assertThat(keyspace.getName(), is("beautifulKeyspaceName"));
-        assertThat(keyspace.getReplicationFactor(), is(1));
-        assertThat(keyspace.getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
+		KeyspaceModel keyspace = dataSet.getKeyspace();
+		assertThat(keyspace, notNullValue());
+		assertThat(keyspace.getName(), is("beautifulKeyspaceName"));
+		assertThat(keyspace.getReplicationFactor(), is(1));
+		assertThat(keyspace.getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
 
-        List<ColumnFamilyModel> actualColumnFamilies = dataSet.getColumnFamilies();
-        assertThat(actualColumnFamilies, notNullValue());
-        assertThat(actualColumnFamilies.size(), is(1));
+		List<ColumnFamilyModel> actualColumnFamilies = dataSet.getColumnFamilies();
+		assertThat(actualColumnFamilies, notNullValue());
+		assertThat(actualColumnFamilies.size(), is(1));
 
-        ColumnFamilyModel actualColumnFamily1 = actualColumnFamilies.get(0);
-        assertThat(actualColumnFamily1, notNullValue());
-        assertThat(actualColumnFamily1.getName(), is("columnFamily1"));
-        assertThat(actualColumnFamily1.getType(), is(ColumnType.STANDARD));
-        assertThat(actualColumnFamily1.getKeyType().getTypeName(), is(ComparatorType.BYTESTYPE.getTypeName()));
-        assertThat(actualColumnFamily1.getComparatorType().getTypeName(), is(ComparatorType.BYTESTYPE.getTypeName()));
-        assertThat(actualColumnFamily1.getSubComparatorType(), nullValue());
-    }
+		ColumnFamilyModel actualColumnFamily1 = actualColumnFamilies.get(0);
+		assertThat(actualColumnFamily1, notNullValue());
+		assertThat(actualColumnFamily1.getName(), is("columnFamily1"));
+		assertThat(actualColumnFamily1.getType(), is(ColumnType.STANDARD));
+		assertThat(actualColumnFamily1.getKeyType().getTypeName(), is(ComparatorType.BYTESTYPE.getTypeName()));
+		assertThat(actualColumnFamily1.getComparatorType().getTypeName(), is(ComparatorType.BYTESTYPE.getTypeName()));
+		assertThat(actualColumnFamily1.getSubComparatorType(), nullValue());
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfNull() {
-        DataSet dataSet = new ClassPathJsonDataSet(null);
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfNull() {
+		DataSet dataSet = new ClassPathJsonDataSet(null);
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfDataSetNotExist() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/unknown.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfDataSetNotExist() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/unknown.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfMissingKeyspaceName() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadMissingKeyspaceName.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfMissingKeyspaceName() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadMissingKeyspaceName.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidStrategy() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadUnknownStrategy.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidStrategy() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadUnknownStrategy.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfMissingColumnFamilyName() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadMissingColumnFamilyName.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfMissingColumnFamilyName() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadMissingColumnFamilyName.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidColumnFamilyType() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidColumnFamilyType.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidColumnFamilyType() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidColumnFamilyType.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidRowKeyType() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidKeyType.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidRowKeyType() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidKeyType.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidComparatorType() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidComparatorType.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidComparatorType() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidComparatorType.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidSubComparatorType() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidSubComparatorType.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidSubComparatorType() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidSubComparatorType.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidDefaultColumnValueType() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidDefaultColumnValueType.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAJsonDataSetStructureBecauseOfInvalidDefaultColumnValueType() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadInvalidDefaultColumnValueType.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test
-    public void shouldGetAJsonDataSetWithData() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefaultValues.json");
-        assertThat(dataSet, notNullValue());
-        assertThat(dataSet.getKeyspace(), notNullValue());
+	@Test
+	public void shouldGetAJsonDataSetWithData() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefaultValues.json");
+		assertThat(dataSet, notNullValue());
+		assertThat(dataSet.getKeyspace(), notNullValue());
 
-        List<ColumnFamilyModel> actualColumnFamilies = dataSet.getColumnFamilies();
-        assertThat(actualColumnFamilies, notNullValue());
-        assertThat(actualColumnFamilies.size(), is(1));
+		List<ColumnFamilyModel> actualColumnFamilies = dataSet.getColumnFamilies();
+		assertThat(actualColumnFamilies, notNullValue());
+		assertThat(actualColumnFamilies.size(), is(1));
 
-        ColumnFamilyModel actualColumnFamily1 = actualColumnFamilies.get(0);
-        assertThat(actualColumnFamily1, notNullValue());
-        assertThat(actualColumnFamily1.getName(), is("columnFamily1"));
+		ColumnFamilyModel actualColumnFamily1 = actualColumnFamilies.get(0);
+		assertThat(actualColumnFamily1, notNullValue());
+		assertThat(actualColumnFamily1.getName(), is("columnFamily1"));
 
-        List<RowModel> actualRows = actualColumnFamily1.getRows();
-        assertThat(actualRows, notNullValue());
-        assertThat(actualRows.size(), is(1));
+		List<RowModel> actualRows = actualColumnFamily1.getRows();
+		assertThat(actualRows, notNullValue());
+		assertThat(actualRows.size(), is(1));
 
-        RowModel actualRow = actualRows.get(0);
-        assertThat(actualRow, notNullValue());
-        assertThat(actualRow.getKey().getValue(), is("01"));
-        assertThat(actualRow.getKey().getType(), is(GenericTypeEnum.BYTES_TYPE));
+		RowModel actualRow = actualRows.get(0);
+		assertThat(actualRow, notNullValue());
+		assertThat(actualRow.getKey().getValue(), is("01"));
+		assertThat(actualRow.getKey().getType(), is(GenericTypeEnum.BYTES_TYPE));
 
-        List<ColumnModel> actualColumns = actualRow.getColumns();
-        assertThat(actualColumns, notNullValue());
-        assertThat(actualColumns.size(), is(1));
+		List<ColumnModel> actualColumns = actualRow.getColumns();
+		assertThat(actualColumns, notNullValue());
+		assertThat(actualColumns.size(), is(1));
 
-        ColumnModel actualColumn = actualColumns.get(0);
-        assertThat(actualColumn, notNullValue());
-        assertThat(actualColumn.getName().getValue(), is("02"));
-        assertThat(actualColumn.getName().getType(), is(GenericTypeEnum.BYTES_TYPE));
-        assertThat(actualColumn.getValue().getValue(), is("03"));
-        assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.BYTES_TYPE));
-    }
+		ColumnModel actualColumn = actualColumns.get(0);
+		assertThat(actualColumn, notNullValue());
+		assertThat(actualColumn.getName().getValue(), is("02"));
+		assertThat(actualColumn.getName().getType(), is(GenericTypeEnum.BYTES_TYPE));
+		assertThat(actualColumn.getValue().getValue(), is("03"));
+		assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.BYTES_TYPE));
+	}
 
-    @Test
-    public void shouldGetAJsonDataSetWithDefinedValuesAndData() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefinedValues.json");
-        assertThat(dataSet, notNullValue());
+	@Test
+	public void shouldGetAJsonDataSetWithDefinedValuesAndData() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefinedValues.json");
+		assertThat(dataSet, notNullValue());
 
-        KeyspaceModel actualKeyspace = dataSet.getKeyspace();
-        assertThat(actualKeyspace, notNullValue());
-        assertThat(actualKeyspace.getName(), is("beautifulDefinedKeyspaceName"));
-        assertThat(actualKeyspace.getReplicationFactor(), is(1));
-        assertThat(actualKeyspace.getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
+		KeyspaceModel actualKeyspace = dataSet.getKeyspace();
+		assertThat(actualKeyspace, notNullValue());
+		assertThat(actualKeyspace.getName(), is("beautifulDefinedKeyspaceName"));
+		assertThat(actualKeyspace.getReplicationFactor(), is(1));
+		assertThat(actualKeyspace.getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
 
-        assertThat(dataSet.getColumnFamilies(), notNullValue());
-        assertThat(dataSet.getColumnFamilies().size(), is(4));
+		assertThat(dataSet.getColumnFamilies(), notNullValue());
+		assertThat(dataSet.getColumnFamilies().size(), is(4));
 
-        ColumnFamilyModel actualColumnFamily1 = dataSet.getColumnFamilies().get(0);
-        assertThat(actualColumnFamily1, notNullValue());
-        assertThat(actualColumnFamily1.getName(), is("columnFamily1"));
-        assertThat(actualColumnFamily1.getKeyType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
-        assertThat(actualColumnFamily1.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
-        assertThat(actualColumnFamily1.getSubComparatorType(), is(nullValue()));
-        assertThat(actualColumnFamily1.getComment(), is("amazing comment"));
-        assertThat(actualColumnFamily1.getCompactionStrategy(), is("LeveledCompactionStrategy"));
-        assertThat(actualColumnFamily1.getCompactionStrategyOptions().get(0).getName(), is("sstable_size_in_mb"));
-        assertThat(actualColumnFamily1.getCompactionStrategyOptions().get(0).getValue(), is("10"));
-        assertThat(actualColumnFamily1.getGcGraceSeconds(), is(9999));
-        assertThat(actualColumnFamily1.getMaxCompactionThreshold(), is(31));
-        assertThat(actualColumnFamily1.getMinCompactionThreshold(), is(3));
-        assertThat(actualColumnFamily1.getReadRepairChance(), is(0.1d));
-        assertThat(actualColumnFamily1.getReplicationOnWrite(), is(Boolean.FALSE));
+		ColumnFamilyModel actualColumnFamily1 = dataSet.getColumnFamilies().get(0);
+		assertThat(actualColumnFamily1, notNullValue());
+		assertThat(actualColumnFamily1.getName(), is("columnFamily1"));
+		assertThat(actualColumnFamily1.getKeyType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(actualColumnFamily1.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(actualColumnFamily1.getSubComparatorType(), is(nullValue()));
+		assertThat(actualColumnFamily1.getComment(), is("amazing comment"));
+		assertThat(actualColumnFamily1.getCompactionStrategy(), is("LeveledCompactionStrategy"));
+		assertThat(actualColumnFamily1.getCompactionStrategyOptions().get(0).getName(), is("sstable_size_in_mb"));
+		assertThat(actualColumnFamily1.getCompactionStrategyOptions().get(0).getValue(), is("10"));
+		assertThat(actualColumnFamily1.getGcGraceSeconds(), is(9999));
+		assertThat(actualColumnFamily1.getMaxCompactionThreshold(), is(31));
+		assertThat(actualColumnFamily1.getMinCompactionThreshold(), is(3));
+		assertThat(actualColumnFamily1.getReadRepairChance(), is(0.1d));
+		assertThat(actualColumnFamily1.getReplicationOnWrite(), is(Boolean.FALSE));
 
-        List<RowModel> actualRows1 = actualColumnFamily1.getRows();
-        assertThat(actualRows1, notNullValue());
-        assertThat(actualRows1.size(), is(1));
+		List<RowModel> actualRows1 = actualColumnFamily1.getRows();
+		assertThat(actualRows1, notNullValue());
+		assertThat(actualRows1.size(), is(1));
 
-        RowModel actualRow11 = actualRows1.get(0);
-        assertThat(actualRow11, notNullValue());
-        assertThat(actualRow11.getKey().getValue(), is("key01"));
-        assertThat(actualRow11.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		RowModel actualRow11 = actualRows1.get(0);
+		assertThat(actualRow11, notNullValue());
+		assertThat(actualRow11.getKey().getValue(), is("key01"));
+		assertThat(actualRow11.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 
-        List<ColumnModel> actualColumns11 = actualRow11.getColumns();
-        assertThat(actualColumns11, notNullValue());
-        assertThat(actualColumns11.size(), is(1));
+		List<ColumnModel> actualColumns11 = actualRow11.getColumns();
+		assertThat(actualColumns11, notNullValue());
+		assertThat(actualColumns11.size(), is(1));
 
-        ColumnModel actualColumn111 = actualColumns11.get(0);
-        assertThat(actualColumn111, notNullValue());
-        assertThat(actualColumn111.getName().getValue(), is("columnName1"));
-        assertThat(actualColumn111.getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
-        assertThat(actualColumn111.getValue().getValue(), is("columnValue1"));
-        assertThat(actualColumn111.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		ColumnModel actualColumn111 = actualColumns11.get(0);
+		assertThat(actualColumn111, notNullValue());
+		assertThat(actualColumn111.getName().getValue(), is("columnName1"));
+		assertThat(actualColumn111.getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(actualColumn111.getValue().getValue(), is("columnValue1"));
+		assertThat(actualColumn111.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 
-        ColumnFamilyModel actualColumnFamily2 = dataSet.getColumnFamilies().get(1);
-        assertThat(actualColumnFamily2, notNullValue());
-        assertThat(actualColumnFamily2.getName(), is("columnFamily2"));
-        assertThat(actualColumnFamily2.getKeyType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
-        assertThat(actualColumnFamily2.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
-        assertThat(actualColumnFamily2.getSubComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		ColumnFamilyModel actualColumnFamily2 = dataSet.getColumnFamilies().get(1);
+		assertThat(actualColumnFamily2, notNullValue());
+		assertThat(actualColumnFamily2.getName(), is("columnFamily2"));
+		assertThat(actualColumnFamily2.getKeyType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(actualColumnFamily2.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(actualColumnFamily2.getSubComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
 
-        List<RowModel> actualRows2 = actualColumnFamily2.getRows();
-        assertThat(actualRows2, notNullValue());
-        assertThat(actualRows2.size(), is(1));
+		List<RowModel> actualRows2 = actualColumnFamily2.getRows();
+		assertThat(actualRows2, notNullValue());
+		assertThat(actualRows2.size(), is(1));
 
-        RowModel actualRow21 = actualRows2.get(0);
-        assertThat(actualRow21, notNullValue());
-        assertThat(actualRow21.getKey().getValue(), is("key02"));
-        assertThat(actualRow21.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
-        assertThat(actualRow21.getColumns(), notNullValue());
-        assertThat(actualRow21.getColumns().isEmpty(), is(true));
+		RowModel actualRow21 = actualRows2.get(0);
+		assertThat(actualRow21, notNullValue());
+		assertThat(actualRow21.getKey().getValue(), is("key02"));
+		assertThat(actualRow21.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(actualRow21.getColumns(), notNullValue());
+		assertThat(actualRow21.getColumns().isEmpty(), is(true));
 
-        List<SuperColumnModel> actualSuperColumns21 = actualRow21.getSuperColumns();
-        assertThat(actualSuperColumns21, notNullValue());
-        assertThat(actualSuperColumns21.size(), is(1));
-        SuperColumnModel actualSuperColumn211 = actualSuperColumns21.get(0);
-        assertThat(actualSuperColumn211, notNullValue());
-        assertThat(actualSuperColumn211.getName().getValue(), is("superColumnName2"));
-        assertThat(actualSuperColumn211.getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		List<SuperColumnModel> actualSuperColumns21 = actualRow21.getSuperColumns();
+		assertThat(actualSuperColumns21, notNullValue());
+		assertThat(actualSuperColumns21.size(), is(1));
+		SuperColumnModel actualSuperColumn211 = actualSuperColumns21.get(0);
+		assertThat(actualSuperColumn211, notNullValue());
+		assertThat(actualSuperColumn211.getName().getValue(), is("superColumnName2"));
+		assertThat(actualSuperColumn211.getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 
-        List<ColumnModel> actualColumns211 = actualSuperColumn211.getColumns();
-        assertThat(actualColumns211, notNullValue());
-        assertThat(actualColumns211.size(), is(1));
+		List<ColumnModel> actualColumns211 = actualSuperColumn211.getColumns();
+		assertThat(actualColumns211, notNullValue());
+		assertThat(actualColumns211.size(), is(1));
 
-        ColumnModel actualColumn2111 = actualColumns211.get(0);
-        assertThat(actualColumn2111, notNullValue());
-        assertThat(actualColumn2111.getName().getValue(), is("columnName2"));
-        assertThat(actualColumn2111.getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
-        assertThat(actualColumn2111.getValue().getValue(), is("2"));
-        assertThat(actualColumn2111.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
-    }
+		ColumnModel actualColumn2111 = actualColumns211.get(0);
+		assertThat(actualColumn2111, notNullValue());
+		assertThat(actualColumn2111.getName().getValue(), is("columnName2"));
+		assertThat(actualColumn2111.getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(actualColumn2111.getValue().getValue(), is("2"));
+		assertThat(actualColumn2111.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
+	}
 
-    @Test
-    public void shouldGetAStandardCounterColumnFamily() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefinedValues.json");
-        List<RowModel> actualRows = dataSet.getColumnFamilies().get(2).getRows();
-        assertThat(actualRows, notNullValue());
-        assertThat(actualRows.size(), is(1));
+	@Test
+	public void shouldGetAStandardCounterColumnFamily() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefinedValues.json");
+		List<RowModel> actualRows = dataSet.getColumnFamilies().get(2).getRows();
+		assertThat(actualRows, notNullValue());
+		assertThat(actualRows.size(), is(1));
 
-        RowModel actualRow1 = actualRows.get(0);
-        assertThat(actualRow1, notNullValue());
-        assertThat(actualRow1.getKey().getValue(), is("key10"));
-        assertThat(actualRow1.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		RowModel actualRow1 = actualRows.get(0);
+		assertThat(actualRow1, notNullValue());
+		assertThat(actualRow1.getKey().getValue(), is("key10"));
+		assertThat(actualRow1.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 
-        List<ColumnModel> actualColumns1 = actualRow1.getColumns();
-        assertThat(actualColumns1, notNullValue());
-        assertThat(actualColumns1.size(), is(1));
+		List<ColumnModel> actualColumns1 = actualRow1.getColumns();
+		assertThat(actualColumns1, notNullValue());
+		assertThat(actualColumns1.size(), is(1));
 
-        ColumnModel actualColumn11 = actualColumns1.get(0);
-        assertThat(actualColumn11, notNullValue());
-        assertThat(actualColumn11.getName().getValue(), is("columnName11"));
-        assertThat(actualColumn11.getValue().getValue(), is("11"));
-        assertThat(actualColumn11.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
-    }
+		ColumnModel actualColumn11 = actualColumns1.get(0);
+		assertThat(actualColumn11, notNullValue());
+		assertThat(actualColumn11.getName().getValue(), is("columnName11"));
+		assertThat(actualColumn11.getValue().getValue(), is("11"));
+		assertThat(actualColumn11.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
+	}
 
-    @Test
-    public void shouldGetASuperCounterColumnFamily() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefinedValues.json");
-        assertThat(dataSet.getColumnFamilies().get(3), notNullValue());
-        assertThat(dataSet.getColumnFamilies().get(3).getName(), is("superCounterColumnFamily"));
+	@Test
+	public void shouldGetASuperCounterColumnFamily() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetDefinedValues.json");
+		assertThat(dataSet.getColumnFamilies().get(3), notNullValue());
+		assertThat(dataSet.getColumnFamilies().get(3).getName(), is("superCounterColumnFamily"));
 
-        List<RowModel> actualRows = dataSet.getColumnFamilies().get(3).getRows();
-        assertThat(actualRows, notNullValue());
-        assertThat(actualRows.size(), is(1));
+		List<RowModel> actualRows = dataSet.getColumnFamilies().get(3).getRows();
+		assertThat(actualRows, notNullValue());
+		assertThat(actualRows.size(), is(1));
 
-        RowModel actualRow = actualRows.get(0);
-        assertThat(actualRow, notNullValue());
-        assertThat(actualRow.getKey().getValue(), is("key10"));
-        assertThat(actualRow.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		RowModel actualRow = actualRows.get(0);
+		assertThat(actualRow, notNullValue());
+		assertThat(actualRow.getKey().getValue(), is("key10"));
+		assertThat(actualRow.getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 
-        List<SuperColumnModel> actualSuperColumns = actualRow.getSuperColumns();
-        assertThat(actualSuperColumns, notNullValue());
-        assertThat(actualSuperColumns.size(), is(1));
+		List<SuperColumnModel> actualSuperColumns = actualRow.getSuperColumns();
+		assertThat(actualSuperColumns, notNullValue());
+		assertThat(actualSuperColumns.size(), is(1));
 
-        SuperColumnModel actualSuperColumn = actualSuperColumns.get(0);
-        assertThat(actualSuperColumn, notNullValue());
-        assertThat(actualSuperColumn.getName().getValue(), is("superColumnName11"));
+		SuperColumnModel actualSuperColumn = actualSuperColumns.get(0);
+		assertThat(actualSuperColumn, notNullValue());
+		assertThat(actualSuperColumn.getName().getValue(), is("superColumnName11"));
 
-        List<ColumnModel> actualColumns = actualSuperColumn.getColumns();
-        assertThat(actualColumns, notNullValue());
-        assertThat(actualColumns.size(), is(1));
+		List<ColumnModel> actualColumns = actualSuperColumn.getColumns();
+		assertThat(actualColumns, notNullValue());
+		assertThat(actualColumns.size(), is(1));
 
-        ColumnModel actualColumn = actualColumns.get(0);
-        assertThat(actualColumn, notNullValue());
-        assertThat(actualColumn.getName().getValue(), is("columnName111"));
-        assertThat(actualColumn.getValue().getValue(), is("111"));
-        assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
-    }
+		ColumnModel actualColumn = actualColumns.get(0);
+		assertThat(actualColumn, notNullValue());
+		assertThat(actualColumn.getName().getValue(), is("columnName111"));
+		assertThat(actualColumn.getValue().getValue(), is("111"));
+		assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetCounterColumnFamilyBecauseThereIsFunctionOverridingDefaultValueType() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadCounterColumnFamilyWithFunction.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetCounterColumnFamilyBecauseThereIsFunctionOverridingDefaultValueType() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetBadCounterColumnFamilyWithFunction.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test
-    public void shouldGetAColumnFamilyWithSecondaryIndex() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithSecondaryIndex.json");
+	@Test
+	public void shouldGetAColumnFamilyWithSecondaryIndex() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithSecondaryIndex.json");
 
-        ColumnMetadataModel actualColumnMetadataModel1 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
-        assertThat(actualColumnMetadataModel1.getColumnName().getValue(), is("columnWithIndexAndUTF8ValidationClass"));
-        assertThat(actualColumnMetadataModel1.getColumnIndexType(), is(ColumnIndexType.KEYS));
-        assertThat(actualColumnMetadataModel1.getValidationClass(), is(ComparatorType.UTF8TYPE));
+		ColumnMetadataModel actualColumnMetadataModel1 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
+		assertThat(actualColumnMetadataModel1.getColumnName().getValue(), is("columnWithIndexAndUTF8ValidationClass"));
+		assertThat(actualColumnMetadataModel1.getColumnIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(actualColumnMetadataModel1.getValidationClass(), is(ComparatorType.UTF8TYPE));
 
-        ColumnMetadataModel actualColumnMetadataModel2 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1);
-        assertThat(actualColumnMetadataModel2.getColumnName().getValue(), is("columnWithIndexAndIndexNameAndUTF8ValidationClass"));
-        assertThat(actualColumnMetadataModel2.getColumnIndexType(), is(ColumnIndexType.KEYS));
-        assertThat(actualColumnMetadataModel2.getValidationClass(), is(ComparatorType.UTF8TYPE));
-        assertThat(actualColumnMetadataModel2.getIndexName(), is("indexNameOfTheIndex"));
+		ColumnMetadataModel actualColumnMetadataModel2 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1);
+		assertThat(actualColumnMetadataModel2.getColumnName().getValue(), is("columnWithIndexAndIndexNameAndUTF8ValidationClass"));
+		assertThat(actualColumnMetadataModel2.getColumnIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(actualColumnMetadataModel2.getValidationClass(), is(ComparatorType.UTF8TYPE));
+		assertThat(actualColumnMetadataModel2.getIndexName(), is("indexNameOfTheIndex"));
 
-        ColumnMetadataModel actualColumnMetadataModel3 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2);
-        assertThat(actualColumnMetadataModel3.getColumnName().getValue(), is("columnWithUTF8ValidationClass"));
-        assertThat(actualColumnMetadataModel3.getColumnIndexType(), nullValue());
-        assertThat(actualColumnMetadataModel3.getValidationClass(), is(ComparatorType.UTF8TYPE));
-    }
+		ColumnMetadataModel actualColumnMetadataModel3 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2);
+		assertThat(actualColumnMetadataModel3.getColumnName().getValue(), is("columnWithUTF8ValidationClass"));
+		assertThat(actualColumnMetadataModel3.getColumnIndexType(), nullValue());
+		assertThat(actualColumnMetadataModel3.getValidationClass(), is(ComparatorType.UTF8TYPE));
+	}
 
-    @Test
-    public void shouldGetAColumnFamilyWithCompositeType() throws Exception {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithCompositeType.json");
-        assertThatKeyspaceModelWithCompositeTypeIsOk(dataSet);
-    }
+	@Test
+	public void shouldGetAColumnFamilyWithCompositeType() throws Exception {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithCompositeType.json");
+		assertThatKeyspaceModelWithCompositeTypeIsOk(dataSet);
+	}
 
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAColumnFamilyWithCompositeType() throws Exception {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithBadCompositeType.json");
-        dataSet.getKeyspace();
-    }
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAColumnFamilyWithCompositeType() throws Exception {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithBadCompositeType.json");
+		dataSet.getKeyspace();
+	}
 
-    @Test
-    public void shouldGetAColumnFamilyWithNullColumnValue() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithNullColumnValue.json");
-        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamilyModel.getName(), is("columnFamilyWithNullColumnValue"));
-        ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
-        assertThat(columnModel.getName().getValue(), is("columnWithNullColumnValue"));
-        assertThat(columnModel.getValue(), nullValue());
-    }
+	@Test
+	public void shouldGetAColumnFamilyWithNullColumnValue() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithNullColumnValue.json");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithNullColumnValue"));
+		ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
+		assertThat(columnModel.getName().getValue(), is("columnWithNullColumnValue"));
+		assertThat(columnModel.getValue(), nullValue());
+	}
 
-    @Test
-    public void shouldGetAColumnFamilyWithMetadataAndFunction() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithMetadataAndFunctions.json");
-        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamilyModel.getName(), is("columnFamilyWithMetadata"));
-        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
-        ColumnModel column1 = columns.get(0);
-        assertThat(column1.getName().getValue(), is("column1"));
-        assertThat(column1.getValue().getValue(), is("1"));
-        assertThat(column1.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
+	@Test
+	public void shouldGetAColumnFamilyWithMetadataAndFunction() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithMetadataAndFunctions.json");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithMetadata"));
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+		ColumnModel column1 = columns.get(0);
+		assertThat(column1.getName().getValue(), is("column1"));
+		assertThat(column1.getValue().getValue(), is("1"));
+		assertThat(column1.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
 
-        ColumnModel column2 = columns.get(1);
-        assertThat(column2.getName().getValue(), is("column2"));
-        assertThat(column2.getValue().getValue(), is("2"));
-        assertThat(column2.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
+		ColumnModel column2 = columns.get(1);
+		assertThat(column2.getName().getValue(), is("column2"));
+		assertThat(column2.getValue().getValue(), is("2"));
+		assertThat(column2.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
 
-        ColumnModel column3 = columns.get(2);
-        assertThat(column3.getName().getValue(), is("column3"));
-        assertThat(column3.getValue().getValue(), is("value3"));
-        assertThat(column3.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
-    }
+		ColumnModel column3 = columns.get(2);
+		assertThat(column3.getName().getValue(), is("column3"));
+		assertThat(column3.getValue().getValue(), is("value3"));
+		assertThat(column3.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+	}
 
-    @Test
-    public void shouldUseComparatorTypeForMetadataColumnName() {
-        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithComparatorType.json");
-        ColumnMetadataModel columnMetadata = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
-        assertThat(columnMetadata.getColumnName().getType(), is(GenericTypeEnum.TIME_UUID_TYPE));
-    }
+	@Test
+	public void shouldUseComparatorTypeForMetadataColumnName() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithComparatorType.json");
+		ColumnMetadataModel columnMetadata = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
+		assertThat(columnMetadata.getColumnName().getType(), is(GenericTypeEnum.TIME_UUID_TYPE));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithColumnsInReverseOrder() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithReversedComparatorOnSimpleType.json");
+
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnSimpleType"));
+		assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(reversed=true)"));
+
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+		ColumnModel column1 = columns.get(0);
+		assertThat(column1.getName().getValue(), is("c"));
+		assertThat(column1.getValue().getValue(), is("c"));
+
+		ColumnModel column2 = columns.get(1);
+		assertThat(column2.getName().getValue(), is("b"));
+		assertThat(column2.getValue().getValue(), is("b"));
+
+		ColumnModel column3 = columns.get(2);
+		assertThat(column3.getName().getValue(), is("a"));
+		assertThat(column3.getValue().getValue(), is("a"));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithCompositeColumnsInReverseOrder() {
+		DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithReversedComparatorOnCompositeTypes.json");
+
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnCompositeTypes"));
+		assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.COMPOSITETYPE.getTypeName()));
+		assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))"));
+
+		GenericTypeEnum[] expecTedTypesBelongingCompositeType = new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE };
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+		assertThat(columns.get(0).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(0).getName().getCompositeValues(), is(new String[] { "12", "aa", "11" }));
+		assertThat(columns.get(0).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(0).getValue().getValue(), is("v6"));
+
+		assertThat(columns.get(1).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(1).getName().getCompositeValues(), is(new String[] { "12", "ab", "12" }));
+		assertThat(columns.get(1).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(1).getValue().getValue(), is("v5"));
+
+		assertThat(columns.get(2).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(2).getName().getCompositeValues(), is(new String[] { "12", "ab", "11" }));
+		assertThat(columns.get(2).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(2).getValue().getValue(), is("v4"));
+
+		assertThat(columns.get(3).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(3).getName().getCompositeValues(), is(new String[] { "11", "aa", "11" }));
+		assertThat(columns.get(3).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(3).getValue().getValue(), is("v3"));
+
+		assertThat(columns.get(4).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(4).getName().getCompositeValues(), is(new String[] { "11", "ab", "12" }));
+		assertThat(columns.get(4).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(4).getValue().getValue(), is("v2"));
+
+		assertThat(columns.get(5).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(5).getName().getCompositeValues(), is(new String[] { "11", "ab", "11" }));
+		assertThat(columns.get(5).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(5).getValue().getValue(), is("v1"));
+	}
 }

--- a/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
+++ b/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
@@ -1,8 +1,18 @@
 package org.cassandraunit.dataset.xml;
 
+import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithCompositeTypeIsOk;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
 import me.prettyprint.hector.api.ddl.ColumnIndexType;
 import me.prettyprint.hector.api.ddl.ColumnType;
 import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import org.apache.commons.lang.StringUtils;
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.dataset.ParseException;
@@ -15,466 +25,519 @@ import org.cassandraunit.model.SuperColumnModel;
 import org.cassandraunit.type.GenericTypeEnum;
 import org.junit.Test;
 
-import java.util.List;
-
-import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithCompositeTypeIsOk;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
 /**
  * @author Jeremy Sevellec
  */
 public class ClasspathXmlDataSetTest {
 
-    @Test
-    public void shouldGetAXmlDataSet() {
-
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
-        assertThat(dataSet, notNullValue());
-    }
-
-    @Test
-    public void shouldNotGetAXmlDataSetBecauseNull() {
-        try {
-            DataSet dataSet = new ClassPathXmlDataSet(null);
-            fail();
-        } catch (ParseException e) {
-            /* nothing to do, it what we want */
-        }
-    }
-
-    @Test
-    public void shouldNotGetAXmlDataSetBecauseItNotExist() {
-        try {
-            DataSet dataSet = new ClassPathXmlDataSet("xml/unknownDataSet.xml");
-            fail();
-        } catch (ParseException e) {
-            /* nothing to do, it what we want */
-        }
-    }
-
-    @Test
-    public void shouldNotGetAXmlDataSetBecauseItIsInvalid() {
-        try {
-            DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetInvalidDataSet.xml");
-            dataSet.getKeyspace();
-            fail();
-        } catch (ParseException e) {
-            /* nothing to do, it what we want */
-            assertThat(StringUtils.contains(e.getMessage(),
-                    "Invalid content was found starting with element 'columnFamily'"), is(Boolean.TRUE));
-        }
-    }
-
-    @Test
-    public void shouldGetKeyspaceWithDefaultValues() {
-
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
-        assertThat(dataSet.getKeyspace(), notNullValue());
-        assertThat(dataSet.getKeyspace().getName(), notNullValue());
-        assertThat(dataSet.getKeyspace().getName(), is("beautifulKeyspaceName"));
-        assertThat(dataSet.getKeyspace().getReplicationFactor(), is(1));
-        assertThat(dataSet.getKeyspace().getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
-
-    }
-
-    @Test
-    public void shouldGetKeyspaceWithDefinedValues() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
-        assertThat(dataSet.getKeyspace(), notNullValue());
-        assertThat(dataSet.getKeyspace().getName(), notNullValue());
-        assertThat(dataSet.getKeyspace().getName(), is("otherKeyspaceName"));
-        assertThat(dataSet.getKeyspace().getReplicationFactor(), is(2));
-        assertThat(dataSet.getKeyspace().getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
-    }
-
-    @Test
-    public void shouldGetOneColumnFamilyWithDefaultValues() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
-        assertThat(dataSet.getColumnFamilies(), notNullValue());
-        assertThat(dataSet.getColumnFamilies().isEmpty(), is(false));
-
-        ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(0);
-        assertThat(actualColumnFamily, notNullValue());
-        assertThat(actualColumnFamily.getName(), is("columnFamily1"));
-        assertThat(actualColumnFamily.getType(), is(ColumnType.STANDARD));
-        assertThat(actualColumnFamily.getKeyType().getClassName(),is(ComparatorType.BYTESTYPE.getClassName()));
-        assertThat(actualColumnFamily.getComparatorType().getClassName(),is(ComparatorType.BYTESTYPE.getClassName()));
-        assertThat(actualColumnFamily.getSubComparatorType(), nullValue());
-        assertThat(actualColumnFamily.getDefaultColumnValueType(), nullValue());
-
-    }
-
-    @Test
-    public void shouldGetColumnFamiliesWithDefinedValues() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
-        assertThat(dataSet.getColumnFamilies(), notNullValue());
-        assertThat(dataSet.getColumnFamilies().isEmpty(), is(false));
-
-        ColumnFamilyModel beautifulColumnFamily = dataSet.getColumnFamilies().get(0);
-        assertThat(beautifulColumnFamily, notNullValue());
-        assertThat(beautifulColumnFamily.getName(), is("beautifulColumnFamilyName"));
-        assertThat(beautifulColumnFamily.getType(), is(ColumnType.SUPER));
-        assertThat(beautifulColumnFamily.getKeyType().getClassName(),is(ComparatorType.TIMEUUIDTYPE.getClassName()));
-        assertThat(beautifulColumnFamily.getComparatorType().getClassName(),is(ComparatorType.UTF8TYPE.getClassName()));
-        assertThat(beautifulColumnFamily.getSubComparatorType().getClassName(),is(ComparatorType.LONGTYPE.getClassName()));
-        assertThat(beautifulColumnFamily.getDefaultColumnValueType().getClassName(),is(ComparatorType.UTF8TYPE.getClassName()));
-        assertThat(beautifulColumnFamily.getComment(), is("amazing comment"));
-        assertThat(beautifulColumnFamily.getCompactionStrategy(), is("LeveledCompactionStrategy"));
-        assertThat(beautifulColumnFamily.getCompactionStrategyOptions().get(0).getName(), is("sstable_size_in_mb"));
-        assertThat(beautifulColumnFamily.getCompactionStrategyOptions().get(0).getValue(), is("10"));
-        assertThat(beautifulColumnFamily.getGcGraceSeconds(), is(9999));
-        assertThat(beautifulColumnFamily.getMaxCompactionThreshold(), is(31));
-        assertThat(beautifulColumnFamily.getMinCompactionThreshold(), is(3));
-        assertThat(beautifulColumnFamily.getReadRepairChance(), is(0.1d));
-        assertThat(beautifulColumnFamily.getReplicationOnWrite(), is(Boolean.FALSE));
-
-        ColumnFamilyModel amazingColumnFamily = dataSet.getColumnFamilies().get(1);
-        assertThat(amazingColumnFamily.getName(), is("amazingColumnFamilyName"));
-        assertThat(amazingColumnFamily.getType(), is(ColumnType.STANDARD));
-        assertThat(amazingColumnFamily.getKeyType().getClassName(),
-                is(ComparatorType.UTF8TYPE.getClassName()));
-        assertThat(amazingColumnFamily.getComparatorType().getClassName(),
-                is(ComparatorType.UTF8TYPE.getClassName()));
-    }
-
-    @Test
-    public void shouldGetOneStandardColumnFamilyDataWithDefaultValues() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
-        List<RowModel> rows = dataSet.getColumnFamilies().get(0).getRows();
-        assertThat(rows, notNullValue());
-        assertThat(rows.size(), is(3));
-        verifyStandardRow(rows.get(0), "10", 2, "11", "11", "12", "12");
-        verifyStandardRow(rows.get(1), "20", 3, "21", "21", "22", "22");
-        verifyStandardRow(rows.get(2), "30", 2, "31", "31", "32", "32");
-    }
-
-    private void verifyStandardRow(RowModel row, String expectedRowkey, int expectedSize,
-                                   String expectedFirstColumnName, String expectedFirstColumnValue, String expectedSecondColumnName,
-                                   String expectedSecondColumnValue) {
-        assertThat(row, notNullValue());
-        assertThat(row.getKey().toString(), is(expectedRowkey));
-        assertThat(row.getSuperColumns(), notNullValue());
-        assertThat(row.getSuperColumns().isEmpty(), is(true));
-        assertThat(row.getColumns(), notNullValue());
-        assertThat(row.getColumns().size(), is(expectedSize));
-        assertThat(row.getColumns().get(0), notNullValue());
-        assertThat(row.getColumns().get(0).getName().toString(), is(expectedFirstColumnName));
-        assertThat(row.getColumns().get(0).getValue().toString(), is(expectedFirstColumnValue));
-        assertThat(row.getColumns().get(0), notNullValue());
-        assertThat(row.getColumns().get(1).getName().toString(), is(expectedSecondColumnName));
-        assertThat(row.getColumns().get(1).getValue().toString(), is(expectedSecondColumnValue));
-    }
-
-    @Test
-    public void shouldGetOneSuperColumnFamilyData() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
-        assertThat(dataSet.getColumnFamilies().get(0).getRows(), notNullValue());
-        assertThat(dataSet.getColumnFamilies().get(0).getRows().size(), is(2));
-        RowModel actualrow0 = dataSet.getColumnFamilies().get(0).getRows().get(0);
-        assertThat(actualrow0, notNullValue());
-        assertThat(actualrow0.getKey().toString(), is("13816710-1dd2-11b2-879a-782bcb80ff6a"));
-        assertThat(actualrow0.getColumns(), notNullValue());
-        assertThat(actualrow0.getColumns().isEmpty(), is(true));
-        assertThat(actualrow0.getSuperColumns(), notNullValue());
-        assertThat(actualrow0.getSuperColumns().size(), is(2));
-
-        SuperColumnModel actualSuperColumn = actualrow0.getSuperColumns().get(0);
-        assertThat(actualSuperColumn, notNullValue());
-        assertThat(actualSuperColumn.getName().toString(), is("name11"));
-        assertThat(actualSuperColumn.getColumns(), notNullValue());
-        assertThat(actualSuperColumn.getColumns().size(), is(2));
-
-        ColumnModel actualColumn0OfRow0 = actualSuperColumn.getColumns().get(0);
-        assertThat(actualColumn0OfRow0, notNullValue());
-        assertThat(actualColumn0OfRow0.getName().toString(), is("111"));
-        assertThat(actualColumn0OfRow0.getValue().toString(), is("value111"));
-
-        ColumnModel actualColumn1OfRow0 = actualSuperColumn.getColumns().get(1);
-        assertThat(actualColumn1OfRow0, notNullValue());
-        assertThat(actualColumn1OfRow0.getName().toString(), is("112"));
-        assertThat(actualColumn1OfRow0.getValue().toString(), is("value112"));
-
-        SuperColumnModel actualSuperColumn1OfRow0 = actualrow0.getSuperColumns().get(1);
-        assertThat(actualSuperColumn1OfRow0.getName().toString(), is("name12"));
-        assertThat(actualSuperColumn1OfRow0.getColumns(), notNullValue());
-        assertThat(actualSuperColumn1OfRow0.getColumns().size(), is(2));
-
-        ColumnModel actualColumn0OfSuperColumn1OofRow0 = actualSuperColumn1OfRow0.getColumns().get(0);
-        assertThat(actualColumn0OfSuperColumn1OofRow0, notNullValue());
-        assertThat(actualColumn0OfSuperColumn1OofRow0.getName().toString(), is("121"));
-        assertThat(actualColumn0OfSuperColumn1OofRow0.getValue().toString(), is("value121"));
-
-        ColumnModel actualColumn1OfSuperColumn1ofRow0 = actualSuperColumn1OfRow0.getColumns().get(1);
-        assertThat(actualColumn1OfSuperColumn1ofRow0, notNullValue());
-        assertThat(actualColumn1OfSuperColumn1ofRow0.getName().toString(), is("122"));
-        assertThat(actualColumn1OfSuperColumn1ofRow0.getValue().toString(), is("value122"));
-
-        RowModel row1 = dataSet.getColumnFamilies().get(0).getRows().get(1);
-        assertThat(row1, notNullValue());
-        assertThat(row1.getKey().toString(), is("13818e20-1dd2-11b2-879a-782bcb80ff6a"));
-        assertThat(row1.getColumns(), notNullValue());
-        assertThat(row1.getColumns().isEmpty(), is(true));
-        assertThat(row1.getSuperColumns(), notNullValue());
-        assertThat(row1.getSuperColumns().size(), is(3));
-
-        SuperColumnModel actualSuperColumn0OfRow1 = row1.getSuperColumns().get(0);
-        assertThat(actualSuperColumn0OfRow1, notNullValue());
-        assertThat(actualSuperColumn0OfRow1.getName().toString(), is("name21"));
-        assertThat(actualSuperColumn0OfRow1.getColumns(), notNullValue());
-        assertThat(actualSuperColumn0OfRow1.getColumns().size(), is(2));
-
-        ColumnModel actualColumn0OfSuperColum0OfRow1 = actualSuperColumn0OfRow1.getColumns().get(0);
-        assertThat(actualColumn0OfSuperColum0OfRow1, notNullValue());
-        assertThat(actualColumn0OfSuperColum0OfRow1.getName().toString(), is("211"));
-        assertThat(actualColumn0OfSuperColum0OfRow1.getValue().toString(), is("value211"));
-
-        ColumnModel actualColumn1OfSuperColum0OfRow1 = actualSuperColumn0OfRow1.getColumns().get(1);
-        assertThat(actualColumn1OfSuperColum0OfRow1, notNullValue());
-        assertThat(actualColumn1OfSuperColum0OfRow1.getName().toString(), is("212"));
-        assertThat(actualColumn1OfSuperColum0OfRow1.getValue().toString(), is("value212"));
-
-        SuperColumnModel actualSuperColumn1OfRow1 = row1.getSuperColumns().get(1);
-        assertThat(actualSuperColumn1OfRow1.getName().toString(), is("name22"));
-        assertThat(actualSuperColumn1OfRow1.getColumns(), notNullValue());
-        assertThat(actualSuperColumn1OfRow1.getColumns().size(), is(2));
-
-        ColumnModel actualColumn0OfSuperCOlumn10OfRow1 = actualSuperColumn1OfRow1.getColumns().get(0);
-        assertThat(actualColumn0OfSuperCOlumn10OfRow1, notNullValue());
-        assertThat(actualColumn0OfSuperCOlumn10OfRow1.getName().toString(), is("221"));
-        assertThat(actualColumn0OfSuperCOlumn10OfRow1.getValue().toString(), is("value221"));
-
-        ColumnModel actualColumn1OfSuperCOlumn10OfRow1 = actualSuperColumn1OfRow1.getColumns().get(1);
-        assertThat(actualColumn1OfSuperCOlumn10OfRow1, notNullValue());
-        assertThat(actualColumn1OfSuperCOlumn10OfRow1.getName().toString(), is("222"));
-        assertThat(actualColumn1OfSuperCOlumn10OfRow1.getValue().toString(), is("value222"));
-
-        SuperColumnModel actualSuperColumnModel2OfRow1 = row1.getSuperColumns().get(2);
-        assertThat(actualSuperColumnModel2OfRow1.getName().toString(), is("name23"));
-        assertThat(actualSuperColumnModel2OfRow1.getColumns(), notNullValue());
-        assertThat(actualSuperColumnModel2OfRow1.getColumns().size(), is(1));
-
-        ColumnModel actualColumn0OfSuperColumn2OfRow1 = actualSuperColumnModel2OfRow1.getColumns().get(0);
-        assertThat(actualColumn0OfSuperColumn2OfRow1, notNullValue());
-        assertThat(actualColumn0OfSuperColumn2OfRow1.getName().toString(), is("231"));
-        assertThat(actualColumn0OfSuperColumn2OfRow1.getValue().toString(), is("value231"));
-    }
-
-    @Test
-    public void shouldGetDefaultBytesTypeForColumnValue() throws Exception {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetColumnValueTest.xml");
-
-        ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(0);
-        assertThat(actualColumnFamily, notNullValue());
-        assertThat(actualColumnFamily.getName(), is("beautifulColumnFamilyName"));
-        assertThat(actualColumnFamily.getRows(), notNullValue());
-
-        RowModel actualRow = actualColumnFamily.getRows().get(0);
-        assertThat(actualRow, notNullValue());
-        assertThat(actualRow.getColumns(), notNullValue());
-
-        ColumnModel actualColumn = actualRow.getColumns().get(0);
-        assertThat(actualColumn, notNullValue());
-        assertThat(actualColumn.getValue().toString(), is("11"));
-        assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.BYTES_TYPE));
-    }
-
-    @Test
-    public void shouldGetDefaultUTF8TypeForColumnValue() throws Exception {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetColumnValueTest.xml");
-        ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(1);
-        assertThat(actualColumnFamily, notNullValue());
-        assertThat(actualColumnFamily.getName(), is("beautifulColumnFamilyName2"));
-        assertThat(actualColumnFamily.getRows(), notNullValue());
-        RowModel actualRow = actualColumnFamily.getRows().get(0);
-        assertThat(actualRow, notNullValue());
-        assertThat(actualRow.getColumns(), notNullValue());
-
-        ColumnModel actualColumn = actualRow.getColumns().get(0);
-        assertThat(actualColumn, notNullValue());
-        assertThat(actualColumn.getValue().toString(), is("11"));
-        assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
-    }
-
-    @Test
-    public void shouldGetDefaultUTF8TypeAndDefinedLongTypeForColumnValue() throws Exception {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetColumnValueTest.xml");
-        ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(2);
-        assertThat(actualColumnFamily, notNullValue());
-        assertThat(actualColumnFamily.getName(), is("beautifulColumnFamilyName3"));
-        assertThat(actualColumnFamily.getRows(), notNullValue());
-
-        RowModel actualRowOfColumnFamily = actualColumnFamily.getRows().get(0);
-        assertThat(actualRowOfColumnFamily, notNullValue());
-        assertThat(actualRowOfColumnFamily.getColumns(), notNullValue());
-        ColumnModel actualColumn0OfColumnFamily = actualRowOfColumnFamily.getColumns().get(0);
-        assertThat(actualColumn0OfColumnFamily, notNullValue());
-        assertThat(actualColumn0OfColumnFamily.getValue().toString(), is("1"));
-        assertThat(actualColumn0OfColumnFamily.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
-
-        ColumnModel actualColumn1OfColumnFamily = actualRowOfColumnFamily.getColumns().get(1);
-        assertThat(actualColumn1OfColumnFamily, notNullValue());
-        assertThat(actualColumn1OfColumnFamily.getValue().toString(), is("value12"));
-        assertThat(actualColumn1OfColumnFamily.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
-    }
-
-    @Test
-    public void shouldGetCounterStandardColumnFamily() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
-
-        ColumnFamilyModel actualColumnFamilyModel2 = dataSet.getColumnFamilies().get(2);
-        assertThat(actualColumnFamilyModel2.getName(), is("counterStandardColumnFamilyName"));
-        assertThat(actualColumnFamilyModel2.getType(), is(ColumnType.STANDARD));
-        assertThat(actualColumnFamilyModel2.getKeyType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
-        assertThat(actualColumnFamilyModel2.getKeyType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
-        assertThat(actualColumnFamilyModel2.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
-        assertThat(actualColumnFamilyModel2.getDefaultColumnValueType().getClassName(), is(ComparatorType.COUNTERTYPE.getClassName()));
-        assertThat(actualColumnFamilyModel2.getRows(), notNullValue());
-        assertThat(actualColumnFamilyModel2.getRows().size(), is(1));
-
-        RowModel actualRowOfColumnFamily2 = actualColumnFamilyModel2.getRows().get(0);
-        assertThat(actualRowOfColumnFamily2, notNullValue());
-        assertThat(actualRowOfColumnFamily2.getColumns(), notNullValue());
-        assertThat(actualRowOfColumnFamily2.getColumns().size(), is(2));
-
-        ColumnModel actualColumn0OfRowOfColumnFamily2 = actualRowOfColumnFamily2.getColumns().get(0);
-        assertThat(actualColumn0OfRowOfColumnFamily2, notNullValue());
-        assertThat(actualColumn0OfRowOfColumnFamily2.getName().getValue(), is("counter11"));
-        assertThat(actualColumn0OfRowOfColumnFamily2.getValue().getValue(), is("11"));
-        assertThat(actualColumn0OfRowOfColumnFamily2.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
-
-        ColumnModel actualColumn1OfRowOfColumnFamily2 = actualRowOfColumnFamily2.getColumns().get(1);
-        assertThat(actualColumn1OfRowOfColumnFamily2, notNullValue());
-        assertThat(actualColumn1OfRowOfColumnFamily2.getName().getValue(), is("counter12"));
-        assertThat(actualColumn1OfRowOfColumnFamily2.getValue().getValue(), is("12"));
-        assertThat(actualColumn1OfRowOfColumnFamily2.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
-    }
-
-    @Test
-    public void shouldGetCounterSuperColumnFamily() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
-        ColumnFamilyModel actualCounterSupercolumnFamilyModel = dataSet.getColumnFamilies().get(3);
-        assertThat(actualCounterSupercolumnFamilyModel.getName(), is("counterSuperColumnFamilyName"));
-        assertThat(actualCounterSupercolumnFamilyModel.getType(), is(ColumnType.SUPER));
-        assertThat(actualCounterSupercolumnFamilyModel.getKeyType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
-        assertThat(actualCounterSupercolumnFamilyModel.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
-        assertThat(actualCounterSupercolumnFamilyModel.getDefaultColumnValueType().getClassName(), is(ComparatorType.COUNTERTYPE.getClassName()));
-
-        assertThat(actualCounterSupercolumnFamilyModel.getRows(), notNullValue());
-        assertThat(actualCounterSupercolumnFamilyModel.getRows().size(), is(1));
-        assertThat(actualCounterSupercolumnFamilyModel.getRows().get(0), notNullValue());
-        assertThat(actualCounterSupercolumnFamilyModel.getRows().get(0).getSuperColumns(), notNullValue());
-        assertThat(actualCounterSupercolumnFamilyModel.getRows().get(0).getSuperColumns().size(), is(1));
-
-        SuperColumnModel actualSuperColumnModel = actualCounterSupercolumnFamilyModel.getRows().get(0).getSuperColumns().get(0);
-        assertThat(actualSuperColumnModel, notNullValue());
-        assertThat(actualSuperColumnModel.getName().getValue(), is("counter11"));
-        assertThat(actualSuperColumnModel.getColumns(), notNullValue());
-        assertThat(actualSuperColumnModel.getColumns().size(), is(2));
-
-        ColumnModel actualColumn0 = actualSuperColumnModel.getColumns().get(0);
-        assertThat(actualColumn0, notNullValue());
-        assertThat(actualColumn0.getName().getValue(), is("counter111"));
-        assertThat(actualColumn0.getValue().getValue(), is("111"));
-        assertThat(actualColumn0.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
-
-        ColumnModel actualColumn1 = actualSuperColumnModel.getColumns().get(1);
-        assertThat(actualColumn1, notNullValue());
-        assertThat(actualColumn1.getName().getValue(), is("counter112"));
-        assertThat(actualColumn1.getValue().getValue(), is("112"));
-        assertThat(actualColumn1.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
-
-    }
-
-    @Test(expected = ParseException.class)
-    public void shouldNotGetCounterColumnFamilyBecauseThereIsFunctionOverridingDefaultValueType() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetBadCounterColumnFamilyWithFunction.xml");
-        dataSet.getKeyspace();
-    }
-
-    @Test
-    public void shouldGetAColumnFamilyWithSecondaryIndex() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithSecondaryIndex.xml");
-        ColumnMetadataModel acutalColumnMetadataModel = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
-        assertThat(acutalColumnMetadataModel.getColumnName().getValue(), is("columnWithIndexAndUTF8ValidationClass"));
-        assertThat(acutalColumnMetadataModel.getColumnIndexType(), is(ColumnIndexType.KEYS));
-        assertThat(acutalColumnMetadataModel.getValidationClass(), is(ComparatorType.UTF8TYPE));
-
-        ColumnMetadataModel actualColumnMetadataModel1 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1);
-        assertThat(actualColumnMetadataModel1.getColumnName().getValue(), is("columnWithIndexAndIndexNameAndUTF8ValidationClass"));
-        assertThat(actualColumnMetadataModel1.getColumnIndexType(), is(ColumnIndexType.KEYS));
-        assertThat(actualColumnMetadataModel1.getValidationClass(), is(ComparatorType.UTF8TYPE));
-        assertThat(actualColumnMetadataModel1.getIndexName(), is("indexNameOfTheIndex"));
-
-        ColumnMetadataModel actualColumnMetadataModel2 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2);
-        assertThat(actualColumnMetadataModel2.getColumnName().getValue(), is("columnWithUTF8ValidationClass"));
-        assertThat(actualColumnMetadataModel2.getColumnIndexType(), nullValue());
-        assertThat(actualColumnMetadataModel2.getValidationClass(), is(ComparatorType.UTF8TYPE));
-    }
-
-    @Test
-    public void shouldGetAColumnFamilyWithCompositeType() throws Exception {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithCompositeType.xml");
-        assertThatKeyspaceModelWithCompositeTypeIsOk(dataSet);
-    }
-
-
-
-
-    @Test(expected = ParseException.class)
-    public void shouldNotGetAColumnFamilyWithCompositeType() throws Exception {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithBadCompositeType.xml");
-        dataSet.getKeyspace();
-    }
-
-    @Test
-    public void shouldGetAColumnFamilyWithNullColumnValue() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithNullColumnValue.xml");
-        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamilyModel.getName(), is("columnFamilyWithNullColumnValue"));
-        ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
-        assertThat(columnModel.getName().getValue(), is("columnWithNullColumnValue"));
-        assertThat(columnModel.getValue(), nullValue());
-    }
-    @Test
-    public void shouldGetAColumnFamilyWithTimestampedColumn() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithTimestamp.xml");
-        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamilyModel.getName(), is("columnFamilyWithTimestampedColumn"));
-        ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
-        assertThat(columnModel.getName().getValue(), is("columnWithTimestamp"));
-        assertThat(columnModel.getTimestamp(), is(2020L));
-    }
-
-    @Test
-    public void shouldGetAColumnFamilyWithMetadataAndFunction() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithMetadataAndFunctions.xml");
-        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamilyModel.getName(), is("columnFamilyWithMetadata"));
-        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
-        ColumnModel column1 = columns.get(0);
-        assertThat(column1.getName().getValue(),is("column1"));
-        assertThat(column1.getValue().getValue(),is("1"));
-        assertThat(column1.getValue().getType(),is(GenericTypeEnum.LONG_TYPE));
-
-        ColumnModel column2 = columns.get(1);
-        assertThat(column2.getName().getValue(),is("column2"));
-        assertThat(column2.getValue().getValue(),is("2"));
-        assertThat(column2.getValue().getType(),is(GenericTypeEnum.LONG_TYPE));
-
-        ColumnModel column3 = columns.get(2);
-        assertThat(column3.getName().getValue(),is("column3"));
-        assertThat(column3.getValue().getValue(),is("value3"));
-        assertThat(column3.getValue().getType(),is(GenericTypeEnum.UTF_8_TYPE));
-    }
+	@Test
+	public void shouldGetAXmlDataSet() {
+
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
+		assertThat(dataSet, notNullValue());
+	}
 
 	@Test
-    public void shouldUseComparatorTypeForMetadataColumnName() {
-        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithComparatorType.xml");
-        ColumnMetadataModel columnMetadata = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
-        assertThat(columnMetadata.getColumnName().getType(), is(GenericTypeEnum.TIME_UUID_TYPE));
-    }
+	public void shouldNotGetAXmlDataSetBecauseNull() {
+		try {
+			DataSet dataSet = new ClassPathXmlDataSet(null);
+			fail();
+		} catch (ParseException e) {
+			/* nothing to do, it what we want */
+		}
+	}
 
+	@Test
+	public void shouldNotGetAXmlDataSetBecauseItNotExist() {
+		try {
+			DataSet dataSet = new ClassPathXmlDataSet("xml/unknownDataSet.xml");
+			fail();
+		} catch (ParseException e) {
+			/* nothing to do, it what we want */
+		}
+	}
 
+	@Test
+	public void shouldNotGetAXmlDataSetBecauseItIsInvalid() {
+		try {
+			DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetInvalidDataSet.xml");
+			dataSet.getKeyspace();
+			fail();
+		} catch (ParseException e) {
+			/* nothing to do, it what we want */
+			assertThat(StringUtils.contains(e.getMessage(), "Invalid content was found starting with element 'columnFamily'"), is(Boolean.TRUE));
+		}
+	}
+
+	@Test
+	public void shouldGetKeyspaceWithDefaultValues() {
+
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
+		assertThat(dataSet.getKeyspace(), notNullValue());
+		assertThat(dataSet.getKeyspace().getName(), notNullValue());
+		assertThat(dataSet.getKeyspace().getName(), is("beautifulKeyspaceName"));
+		assertThat(dataSet.getKeyspace().getReplicationFactor(), is(1));
+		assertThat(dataSet.getKeyspace().getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
+
+	}
+
+	@Test
+	public void shouldGetKeyspaceWithDefinedValues() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
+		assertThat(dataSet.getKeyspace(), notNullValue());
+		assertThat(dataSet.getKeyspace().getName(), notNullValue());
+		assertThat(dataSet.getKeyspace().getName(), is("otherKeyspaceName"));
+		assertThat(dataSet.getKeyspace().getReplicationFactor(), is(2));
+		assertThat(dataSet.getKeyspace().getStrategy(), is(StrategyModel.SIMPLE_STRATEGY));
+	}
+
+	@Test
+	public void shouldGetOneColumnFamilyWithDefaultValues() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
+		assertThat(dataSet.getColumnFamilies(), notNullValue());
+		assertThat(dataSet.getColumnFamilies().isEmpty(), is(false));
+
+		ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(0);
+		assertThat(actualColumnFamily, notNullValue());
+		assertThat(actualColumnFamily.getName(), is("columnFamily1"));
+		assertThat(actualColumnFamily.getType(), is(ColumnType.STANDARD));
+		assertThat(actualColumnFamily.getKeyType().getClassName(), is(ComparatorType.BYTESTYPE.getClassName()));
+		assertThat(actualColumnFamily.getComparatorType().getClassName(), is(ComparatorType.BYTESTYPE.getClassName()));
+		assertThat(actualColumnFamily.getSubComparatorType(), nullValue());
+		assertThat(actualColumnFamily.getDefaultColumnValueType(), nullValue());
+
+	}
+
+	@Test
+	public void shouldGetColumnFamiliesWithDefinedValues() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
+		assertThat(dataSet.getColumnFamilies(), notNullValue());
+		assertThat(dataSet.getColumnFamilies().isEmpty(), is(false));
+
+		ColumnFamilyModel beautifulColumnFamily = dataSet.getColumnFamilies().get(0);
+		assertThat(beautifulColumnFamily, notNullValue());
+		assertThat(beautifulColumnFamily.getName(), is("beautifulColumnFamilyName"));
+		assertThat(beautifulColumnFamily.getType(), is(ColumnType.SUPER));
+		assertThat(beautifulColumnFamily.getKeyType().getClassName(), is(ComparatorType.TIMEUUIDTYPE.getClassName()));
+		assertThat(beautifulColumnFamily.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
+		assertThat(beautifulColumnFamily.getSubComparatorType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
+		assertThat(beautifulColumnFamily.getDefaultColumnValueType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
+		assertThat(beautifulColumnFamily.getComment(), is("amazing comment"));
+		assertThat(beautifulColumnFamily.getCompactionStrategy(), is("LeveledCompactionStrategy"));
+		assertThat(beautifulColumnFamily.getCompactionStrategyOptions().get(0).getName(), is("sstable_size_in_mb"));
+		assertThat(beautifulColumnFamily.getCompactionStrategyOptions().get(0).getValue(), is("10"));
+		assertThat(beautifulColumnFamily.getGcGraceSeconds(), is(9999));
+		assertThat(beautifulColumnFamily.getMaxCompactionThreshold(), is(31));
+		assertThat(beautifulColumnFamily.getMinCompactionThreshold(), is(3));
+		assertThat(beautifulColumnFamily.getReadRepairChance(), is(0.1d));
+		assertThat(beautifulColumnFamily.getReplicationOnWrite(), is(Boolean.FALSE));
+
+		ColumnFamilyModel amazingColumnFamily = dataSet.getColumnFamilies().get(1);
+		assertThat(amazingColumnFamily.getName(), is("amazingColumnFamilyName"));
+		assertThat(amazingColumnFamily.getType(), is(ColumnType.STANDARD));
+		assertThat(amazingColumnFamily.getKeyType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
+		assertThat(amazingColumnFamily.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
+	}
+
+	@Test
+	public void shouldGetOneStandardColumnFamilyDataWithDefaultValues() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefaultValues.xml");
+		List<RowModel> rows = dataSet.getColumnFamilies().get(0).getRows();
+		assertThat(rows, notNullValue());
+		assertThat(rows.size(), is(3));
+		verifyStandardRow(rows.get(0), "10", 2, "11", "11", "12", "12");
+		verifyStandardRow(rows.get(1), "20", 3, "21", "21", "22", "22");
+		verifyStandardRow(rows.get(2), "30", 2, "31", "31", "32", "32");
+	}
+
+	private void verifyStandardRow(RowModel row, String expectedRowkey, int expectedSize, String expectedFirstColumnName, String expectedFirstColumnValue,
+			String expectedSecondColumnName, String expectedSecondColumnValue) {
+		assertThat(row, notNullValue());
+		assertThat(row.getKey().toString(), is(expectedRowkey));
+		assertThat(row.getSuperColumns(), notNullValue());
+		assertThat(row.getSuperColumns().isEmpty(), is(true));
+		assertThat(row.getColumns(), notNullValue());
+		assertThat(row.getColumns().size(), is(expectedSize));
+		assertThat(row.getColumns().get(0), notNullValue());
+		assertThat(row.getColumns().get(0).getName().toString(), is(expectedFirstColumnName));
+		assertThat(row.getColumns().get(0).getValue().toString(), is(expectedFirstColumnValue));
+		assertThat(row.getColumns().get(0), notNullValue());
+		assertThat(row.getColumns().get(1).getName().toString(), is(expectedSecondColumnName));
+		assertThat(row.getColumns().get(1).getValue().toString(), is(expectedSecondColumnValue));
+	}
+
+	@Test
+	public void shouldGetOneSuperColumnFamilyData() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
+		assertThat(dataSet.getColumnFamilies().get(0).getRows(), notNullValue());
+		assertThat(dataSet.getColumnFamilies().get(0).getRows().size(), is(2));
+		RowModel actualrow0 = dataSet.getColumnFamilies().get(0).getRows().get(0);
+		assertThat(actualrow0, notNullValue());
+		assertThat(actualrow0.getKey().toString(), is("13816710-1dd2-11b2-879a-782bcb80ff6a"));
+		assertThat(actualrow0.getColumns(), notNullValue());
+		assertThat(actualrow0.getColumns().isEmpty(), is(true));
+		assertThat(actualrow0.getSuperColumns(), notNullValue());
+		assertThat(actualrow0.getSuperColumns().size(), is(2));
+
+		SuperColumnModel actualSuperColumn = actualrow0.getSuperColumns().get(0);
+		assertThat(actualSuperColumn, notNullValue());
+		assertThat(actualSuperColumn.getName().toString(), is("name11"));
+		assertThat(actualSuperColumn.getColumns(), notNullValue());
+		assertThat(actualSuperColumn.getColumns().size(), is(2));
+
+		ColumnModel actualColumn0OfRow0 = actualSuperColumn.getColumns().get(0);
+		assertThat(actualColumn0OfRow0, notNullValue());
+		assertThat(actualColumn0OfRow0.getName().toString(), is("111"));
+		assertThat(actualColumn0OfRow0.getValue().toString(), is("value111"));
+
+		ColumnModel actualColumn1OfRow0 = actualSuperColumn.getColumns().get(1);
+		assertThat(actualColumn1OfRow0, notNullValue());
+		assertThat(actualColumn1OfRow0.getName().toString(), is("112"));
+		assertThat(actualColumn1OfRow0.getValue().toString(), is("value112"));
+
+		SuperColumnModel actualSuperColumn1OfRow0 = actualrow0.getSuperColumns().get(1);
+		assertThat(actualSuperColumn1OfRow0.getName().toString(), is("name12"));
+		assertThat(actualSuperColumn1OfRow0.getColumns(), notNullValue());
+		assertThat(actualSuperColumn1OfRow0.getColumns().size(), is(2));
+
+		ColumnModel actualColumn0OfSuperColumn1OofRow0 = actualSuperColumn1OfRow0.getColumns().get(0);
+		assertThat(actualColumn0OfSuperColumn1OofRow0, notNullValue());
+		assertThat(actualColumn0OfSuperColumn1OofRow0.getName().toString(), is("121"));
+		assertThat(actualColumn0OfSuperColumn1OofRow0.getValue().toString(), is("value121"));
+
+		ColumnModel actualColumn1OfSuperColumn1ofRow0 = actualSuperColumn1OfRow0.getColumns().get(1);
+		assertThat(actualColumn1OfSuperColumn1ofRow0, notNullValue());
+		assertThat(actualColumn1OfSuperColumn1ofRow0.getName().toString(), is("122"));
+		assertThat(actualColumn1OfSuperColumn1ofRow0.getValue().toString(), is("value122"));
+
+		RowModel row1 = dataSet.getColumnFamilies().get(0).getRows().get(1);
+		assertThat(row1, notNullValue());
+		assertThat(row1.getKey().toString(), is("13818e20-1dd2-11b2-879a-782bcb80ff6a"));
+		assertThat(row1.getColumns(), notNullValue());
+		assertThat(row1.getColumns().isEmpty(), is(true));
+		assertThat(row1.getSuperColumns(), notNullValue());
+		assertThat(row1.getSuperColumns().size(), is(3));
+
+		SuperColumnModel actualSuperColumn0OfRow1 = row1.getSuperColumns().get(0);
+		assertThat(actualSuperColumn0OfRow1, notNullValue());
+		assertThat(actualSuperColumn0OfRow1.getName().toString(), is("name21"));
+		assertThat(actualSuperColumn0OfRow1.getColumns(), notNullValue());
+		assertThat(actualSuperColumn0OfRow1.getColumns().size(), is(2));
+
+		ColumnModel actualColumn0OfSuperColum0OfRow1 = actualSuperColumn0OfRow1.getColumns().get(0);
+		assertThat(actualColumn0OfSuperColum0OfRow1, notNullValue());
+		assertThat(actualColumn0OfSuperColum0OfRow1.getName().toString(), is("211"));
+		assertThat(actualColumn0OfSuperColum0OfRow1.getValue().toString(), is("value211"));
+
+		ColumnModel actualColumn1OfSuperColum0OfRow1 = actualSuperColumn0OfRow1.getColumns().get(1);
+		assertThat(actualColumn1OfSuperColum0OfRow1, notNullValue());
+		assertThat(actualColumn1OfSuperColum0OfRow1.getName().toString(), is("212"));
+		assertThat(actualColumn1OfSuperColum0OfRow1.getValue().toString(), is("value212"));
+
+		SuperColumnModel actualSuperColumn1OfRow1 = row1.getSuperColumns().get(1);
+		assertThat(actualSuperColumn1OfRow1.getName().toString(), is("name22"));
+		assertThat(actualSuperColumn1OfRow1.getColumns(), notNullValue());
+		assertThat(actualSuperColumn1OfRow1.getColumns().size(), is(2));
+
+		ColumnModel actualColumn0OfSuperCOlumn10OfRow1 = actualSuperColumn1OfRow1.getColumns().get(0);
+		assertThat(actualColumn0OfSuperCOlumn10OfRow1, notNullValue());
+		assertThat(actualColumn0OfSuperCOlumn10OfRow1.getName().toString(), is("221"));
+		assertThat(actualColumn0OfSuperCOlumn10OfRow1.getValue().toString(), is("value221"));
+
+		ColumnModel actualColumn1OfSuperCOlumn10OfRow1 = actualSuperColumn1OfRow1.getColumns().get(1);
+		assertThat(actualColumn1OfSuperCOlumn10OfRow1, notNullValue());
+		assertThat(actualColumn1OfSuperCOlumn10OfRow1.getName().toString(), is("222"));
+		assertThat(actualColumn1OfSuperCOlumn10OfRow1.getValue().toString(), is("value222"));
+
+		SuperColumnModel actualSuperColumnModel2OfRow1 = row1.getSuperColumns().get(2);
+		assertThat(actualSuperColumnModel2OfRow1.getName().toString(), is("name23"));
+		assertThat(actualSuperColumnModel2OfRow1.getColumns(), notNullValue());
+		assertThat(actualSuperColumnModel2OfRow1.getColumns().size(), is(1));
+
+		ColumnModel actualColumn0OfSuperColumn2OfRow1 = actualSuperColumnModel2OfRow1.getColumns().get(0);
+		assertThat(actualColumn0OfSuperColumn2OfRow1, notNullValue());
+		assertThat(actualColumn0OfSuperColumn2OfRow1.getName().toString(), is("231"));
+		assertThat(actualColumn0OfSuperColumn2OfRow1.getValue().toString(), is("value231"));
+	}
+
+	@Test
+	public void shouldGetDefaultBytesTypeForColumnValue() throws Exception {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetColumnValueTest.xml");
+
+		ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(0);
+		assertThat(actualColumnFamily, notNullValue());
+		assertThat(actualColumnFamily.getName(), is("beautifulColumnFamilyName"));
+		assertThat(actualColumnFamily.getRows(), notNullValue());
+
+		RowModel actualRow = actualColumnFamily.getRows().get(0);
+		assertThat(actualRow, notNullValue());
+		assertThat(actualRow.getColumns(), notNullValue());
+
+		ColumnModel actualColumn = actualRow.getColumns().get(0);
+		assertThat(actualColumn, notNullValue());
+		assertThat(actualColumn.getValue().toString(), is("11"));
+		assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.BYTES_TYPE));
+	}
+
+	@Test
+	public void shouldGetDefaultUTF8TypeForColumnValue() throws Exception {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetColumnValueTest.xml");
+		ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(1);
+		assertThat(actualColumnFamily, notNullValue());
+		assertThat(actualColumnFamily.getName(), is("beautifulColumnFamilyName2"));
+		assertThat(actualColumnFamily.getRows(), notNullValue());
+		RowModel actualRow = actualColumnFamily.getRows().get(0);
+		assertThat(actualRow, notNullValue());
+		assertThat(actualRow.getColumns(), notNullValue());
+
+		ColumnModel actualColumn = actualRow.getColumns().get(0);
+		assertThat(actualColumn, notNullValue());
+		assertThat(actualColumn.getValue().toString(), is("11"));
+		assertThat(actualColumn.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+	}
+
+	@Test
+	public void shouldGetDefaultUTF8TypeAndDefinedLongTypeForColumnValue() throws Exception {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetColumnValueTest.xml");
+		ColumnFamilyModel actualColumnFamily = dataSet.getColumnFamilies().get(2);
+		assertThat(actualColumnFamily, notNullValue());
+		assertThat(actualColumnFamily.getName(), is("beautifulColumnFamilyName3"));
+		assertThat(actualColumnFamily.getRows(), notNullValue());
+
+		RowModel actualRowOfColumnFamily = actualColumnFamily.getRows().get(0);
+		assertThat(actualRowOfColumnFamily, notNullValue());
+		assertThat(actualRowOfColumnFamily.getColumns(), notNullValue());
+		ColumnModel actualColumn0OfColumnFamily = actualRowOfColumnFamily.getColumns().get(0);
+		assertThat(actualColumn0OfColumnFamily, notNullValue());
+		assertThat(actualColumn0OfColumnFamily.getValue().toString(), is("1"));
+		assertThat(actualColumn0OfColumnFamily.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
+
+		ColumnModel actualColumn1OfColumnFamily = actualRowOfColumnFamily.getColumns().get(1);
+		assertThat(actualColumn1OfColumnFamily, notNullValue());
+		assertThat(actualColumn1OfColumnFamily.getValue().toString(), is("value12"));
+		assertThat(actualColumn1OfColumnFamily.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+	}
+
+	@Test
+	public void shouldGetCounterStandardColumnFamily() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
+
+		ColumnFamilyModel actualColumnFamilyModel2 = dataSet.getColumnFamilies().get(2);
+		assertThat(actualColumnFamilyModel2.getName(), is("counterStandardColumnFamilyName"));
+		assertThat(actualColumnFamilyModel2.getType(), is(ColumnType.STANDARD));
+		assertThat(actualColumnFamilyModel2.getKeyType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
+		assertThat(actualColumnFamilyModel2.getKeyType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
+		assertThat(actualColumnFamilyModel2.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
+		assertThat(actualColumnFamilyModel2.getDefaultColumnValueType().getClassName(), is(ComparatorType.COUNTERTYPE.getClassName()));
+		assertThat(actualColumnFamilyModel2.getRows(), notNullValue());
+		assertThat(actualColumnFamilyModel2.getRows().size(), is(1));
+
+		RowModel actualRowOfColumnFamily2 = actualColumnFamilyModel2.getRows().get(0);
+		assertThat(actualRowOfColumnFamily2, notNullValue());
+		assertThat(actualRowOfColumnFamily2.getColumns(), notNullValue());
+		assertThat(actualRowOfColumnFamily2.getColumns().size(), is(2));
+
+		ColumnModel actualColumn0OfRowOfColumnFamily2 = actualRowOfColumnFamily2.getColumns().get(0);
+		assertThat(actualColumn0OfRowOfColumnFamily2, notNullValue());
+		assertThat(actualColumn0OfRowOfColumnFamily2.getName().getValue(), is("counter11"));
+		assertThat(actualColumn0OfRowOfColumnFamily2.getValue().getValue(), is("11"));
+		assertThat(actualColumn0OfRowOfColumnFamily2.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
+
+		ColumnModel actualColumn1OfRowOfColumnFamily2 = actualRowOfColumnFamily2.getColumns().get(1);
+		assertThat(actualColumn1OfRowOfColumnFamily2, notNullValue());
+		assertThat(actualColumn1OfRowOfColumnFamily2.getName().getValue(), is("counter12"));
+		assertThat(actualColumn1OfRowOfColumnFamily2.getValue().getValue(), is("12"));
+		assertThat(actualColumn1OfRowOfColumnFamily2.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
+	}
+
+	@Test
+	public void shouldGetCounterSuperColumnFamily() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetDefinedValues.xml");
+		ColumnFamilyModel actualCounterSupercolumnFamilyModel = dataSet.getColumnFamilies().get(3);
+		assertThat(actualCounterSupercolumnFamilyModel.getName(), is("counterSuperColumnFamilyName"));
+		assertThat(actualCounterSupercolumnFamilyModel.getType(), is(ColumnType.SUPER));
+		assertThat(actualCounterSupercolumnFamilyModel.getKeyType().getClassName(), is(ComparatorType.LONGTYPE.getClassName()));
+		assertThat(actualCounterSupercolumnFamilyModel.getComparatorType().getClassName(), is(ComparatorType.UTF8TYPE.getClassName()));
+		assertThat(actualCounterSupercolumnFamilyModel.getDefaultColumnValueType().getClassName(), is(ComparatorType.COUNTERTYPE.getClassName()));
+
+		assertThat(actualCounterSupercolumnFamilyModel.getRows(), notNullValue());
+		assertThat(actualCounterSupercolumnFamilyModel.getRows().size(), is(1));
+		assertThat(actualCounterSupercolumnFamilyModel.getRows().get(0), notNullValue());
+		assertThat(actualCounterSupercolumnFamilyModel.getRows().get(0).getSuperColumns(), notNullValue());
+		assertThat(actualCounterSupercolumnFamilyModel.getRows().get(0).getSuperColumns().size(), is(1));
+
+		SuperColumnModel actualSuperColumnModel = actualCounterSupercolumnFamilyModel.getRows().get(0).getSuperColumns().get(0);
+		assertThat(actualSuperColumnModel, notNullValue());
+		assertThat(actualSuperColumnModel.getName().getValue(), is("counter11"));
+		assertThat(actualSuperColumnModel.getColumns(), notNullValue());
+		assertThat(actualSuperColumnModel.getColumns().size(), is(2));
+
+		ColumnModel actualColumn0 = actualSuperColumnModel.getColumns().get(0);
+		assertThat(actualColumn0, notNullValue());
+		assertThat(actualColumn0.getName().getValue(), is("counter111"));
+		assertThat(actualColumn0.getValue().getValue(), is("111"));
+		assertThat(actualColumn0.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
+
+		ColumnModel actualColumn1 = actualSuperColumnModel.getColumns().get(1);
+		assertThat(actualColumn1, notNullValue());
+		assertThat(actualColumn1.getName().getValue(), is("counter112"));
+		assertThat(actualColumn1.getValue().getValue(), is("112"));
+		assertThat(actualColumn1.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
+
+	}
+
+	@Test(expected = ParseException.class)
+	public void shouldNotGetCounterColumnFamilyBecauseThereIsFunctionOverridingDefaultValueType() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetBadCounterColumnFamilyWithFunction.xml");
+		dataSet.getKeyspace();
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithSecondaryIndex() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithSecondaryIndex.xml");
+		ColumnMetadataModel acutalColumnMetadataModel = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
+		assertThat(acutalColumnMetadataModel.getColumnName().getValue(), is("columnWithIndexAndUTF8ValidationClass"));
+		assertThat(acutalColumnMetadataModel.getColumnIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(acutalColumnMetadataModel.getValidationClass(), is(ComparatorType.UTF8TYPE));
+
+		ColumnMetadataModel actualColumnMetadataModel1 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1);
+		assertThat(actualColumnMetadataModel1.getColumnName().getValue(), is("columnWithIndexAndIndexNameAndUTF8ValidationClass"));
+		assertThat(actualColumnMetadataModel1.getColumnIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(actualColumnMetadataModel1.getValidationClass(), is(ComparatorType.UTF8TYPE));
+		assertThat(actualColumnMetadataModel1.getIndexName(), is("indexNameOfTheIndex"));
+
+		ColumnMetadataModel actualColumnMetadataModel2 = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2);
+		assertThat(actualColumnMetadataModel2.getColumnName().getValue(), is("columnWithUTF8ValidationClass"));
+		assertThat(actualColumnMetadataModel2.getColumnIndexType(), nullValue());
+		assertThat(actualColumnMetadataModel2.getValidationClass(), is(ComparatorType.UTF8TYPE));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithCompositeType() throws Exception {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithCompositeType.xml");
+		assertThatKeyspaceModelWithCompositeTypeIsOk(dataSet);
+	}
+
+	@Test(expected = ParseException.class)
+	public void shouldNotGetAColumnFamilyWithCompositeType() throws Exception {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithBadCompositeType.xml");
+		dataSet.getKeyspace();
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithNullColumnValue() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithNullColumnValue.xml");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithNullColumnValue"));
+		ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
+		assertThat(columnModel.getName().getValue(), is("columnWithNullColumnValue"));
+		assertThat(columnModel.getValue(), nullValue());
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithTimestampedColumn() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithTimestamp.xml");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithTimestampedColumn"));
+		ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
+		assertThat(columnModel.getName().getValue(), is("columnWithTimestamp"));
+		assertThat(columnModel.getTimestamp(), is(2020L));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithMetadataAndFunction() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithMetadataAndFunctions.xml");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithMetadata"));
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+		ColumnModel column1 = columns.get(0);
+		assertThat(column1.getName().getValue(), is("column1"));
+		assertThat(column1.getValue().getValue(), is("1"));
+		assertThat(column1.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
+
+		ColumnModel column2 = columns.get(1);
+		assertThat(column2.getName().getValue(), is("column2"));
+		assertThat(column2.getValue().getValue(), is("2"));
+		assertThat(column2.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
+
+		ColumnModel column3 = columns.get(2);
+		assertThat(column3.getName().getValue(), is("column3"));
+		assertThat(column3.getValue().getValue(), is("value3"));
+		assertThat(column3.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+	}
+
+	@Test
+	public void shouldUseComparatorTypeForMetadataColumnName() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithComparatorType.xml");
+		ColumnMetadataModel columnMetadata = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
+		assertThat(columnMetadata.getColumnName().getType(), is(GenericTypeEnum.TIME_UUID_TYPE));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithColumnsInReverseOrder() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithReversedComparatorOnSimpleType.xml");
+
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnSimpleType"));
+		assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(reversed=true)"));
+
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+		ColumnModel column1 = columns.get(0);
+		assertThat(column1.getName().getValue(), is("c"));
+		assertThat(column1.getValue().getValue(), is("c"));
+
+		ColumnModel column2 = columns.get(1);
+		assertThat(column2.getName().getValue(), is("b"));
+		assertThat(column2.getValue().getValue(), is("b"));
+
+		ColumnModel column3 = columns.get(2);
+		assertThat(column3.getName().getValue(), is("a"));
+		assertThat(column3.getValue().getValue(), is("a"));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithCompositeColumnsInReverseOrder() {
+		DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithReversedComparatorOnCompositeTypes.xml");
+
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnCompositeTypes"));
+		assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.COMPOSITETYPE.getTypeName()));
+		assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))"));
+
+		GenericTypeEnum[] expecTedTypesBelongingCompositeType = new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE };
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+		assertThat(columns.get(0).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(0).getName().getCompositeValues(), is(new String[] { "12", "aa", "11" }));
+		assertThat(columns.get(0).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(0).getValue().getValue(), is("v6"));
+
+		assertThat(columns.get(1).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(1).getName().getCompositeValues(), is(new String[] { "12", "ab", "12" }));
+		assertThat(columns.get(1).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(1).getValue().getValue(), is("v5"));
+
+		assertThat(columns.get(2).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(2).getName().getCompositeValues(), is(new String[] { "12", "ab", "11" }));
+		assertThat(columns.get(2).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(2).getValue().getValue(), is("v4"));
+
+		assertThat(columns.get(3).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(3).getName().getCompositeValues(), is(new String[] { "11", "aa", "11" }));
+		assertThat(columns.get(3).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(3).getValue().getValue(), is("v3"));
+
+		assertThat(columns.get(4).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(4).getName().getCompositeValues(), is(new String[] { "11", "ab", "12" }));
+		assertThat(columns.get(4).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(4).getValue().getValue(), is("v2"));
+
+		assertThat(columns.get(5).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(5).getName().getCompositeValues(), is(new String[] { "11", "ab", "11" }));
+		assertThat(columns.get(5).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(5).getValue().getValue(), is("v1"));
+	}
 }

--- a/src/test/java/org/cassandraunit/dataset/yaml/ClasspathYamlDataSetTest.java
+++ b/src/test/java/org/cassandraunit/dataset/yaml/ClasspathYamlDataSetTest.java
@@ -1,8 +1,17 @@
 package org.cassandraunit.dataset.yaml;
 
+import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithCompositeTypeIsOk;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
 import me.prettyprint.hector.api.ddl.ColumnIndexType;
 import me.prettyprint.hector.api.ddl.ColumnType;
 import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.model.ColumnFamilyModel;
@@ -11,15 +20,9 @@ import org.cassandraunit.model.StrategyModel;
 import org.cassandraunit.type.GenericTypeEnum;
 import org.junit.Test;
 
-import java.util.List;
-import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithCompositeTypeIsOk;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-
 /**
- * 
  * @author Jeremy Sevellec
- * 
+ * @author Marc Carre <carre.marc@gmail.com>
  */
 public class ClasspathYamlDataSetTest {
 
@@ -37,10 +40,8 @@ public class ClasspathYamlDataSetTest {
 		assertThat(dataSet.getColumnFamilies().get(0), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(0).getName(), is("columnFamily1"));
 		assertThat(dataSet.getColumnFamilies().get(0).getType(), is(ColumnType.STANDARD));
-		assertThat(dataSet.getColumnFamilies().get(0).getKeyType().getTypeName(),
-				is(ComparatorType.BYTESTYPE.getTypeName()));
-		assertThat(dataSet.getColumnFamilies().get(0).getComparatorType().getTypeName(),
-				is(ComparatorType.BYTESTYPE.getTypeName()));
+		assertThat(dataSet.getColumnFamilies().get(0).getKeyType().getTypeName(), is(ComparatorType.BYTESTYPE.getTypeName()));
+		assertThat(dataSet.getColumnFamilies().get(0).getComparatorType().getTypeName(), is(ComparatorType.BYTESTYPE.getTypeName()));
 		assertThat(dataSet.getColumnFamilies().get(0).getSubComparatorType(), nullValue());
 	}
 
@@ -124,19 +125,14 @@ public class ClasspathYamlDataSetTest {
 		assertThat(dataSet.getColumnFamilies().get(0).getRows().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getKey().getValue(), is("01"));
-		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getKey().getType(),
-				is(GenericTypeEnum.BYTES_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getKey().getType(), is(GenericTypeEnum.BYTES_TYPE));
 		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns(), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0), notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getName().getValue(),
-				is("02"));
-		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getName().getType(),
-				is(GenericTypeEnum.BYTES_TYPE));
-		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getValue().getValue(),
-				is("03"));
-		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getValue().getType(),
-				is(GenericTypeEnum.BYTES_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getName().getValue(), is("02"));
+		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getName().getType(), is(GenericTypeEnum.BYTES_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getValue().getValue(), is("03"));
+		assertThat(dataSet.getColumnFamilies().get(0).getRows().get(0).getColumns().get(0).getValue().getType(), is(GenericTypeEnum.BYTES_TYPE));
 
 	}
 
@@ -152,80 +148,62 @@ public class ClasspathYamlDataSetTest {
 		assertThat(dataSet.getColumnFamilies(), notNullValue());
 		assertThat(dataSet.getColumnFamilies().size(), is(4));
 
-        ColumnFamilyModel columnFamily1 = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamily1, notNullValue());
+		ColumnFamilyModel columnFamily1 = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamily1, notNullValue());
 		assertThat(columnFamily1.getName(), is("columnFamily1"));
-		assertThat(columnFamily1.getKeyType().getTypeName(),
-				is(ComparatorType.UTF8TYPE.getTypeName()));
-		assertThat(columnFamily1.getComparatorType().getTypeName(),
-				is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(columnFamily1.getKeyType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(columnFamily1.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
 		assertThat(columnFamily1.getSubComparatorType(), is(nullValue()));
-        assertThat(columnFamily1.getComment(),is("amazing comment"));
-        assertThat(columnFamily1.getCompactionStrategy(),is("LeveledCompactionStrategy"));
-        assertThat(columnFamily1.getCompactionStrategyOptions().get(0).getName(),is("sstable_size_in_mb"));
-        assertThat(columnFamily1.getCompactionStrategyOptions().get(0).getValue(),is("10"));
-        assertThat(columnFamily1.getGcGraceSeconds(),is(9999));
-        assertThat(columnFamily1.getMaxCompactionThreshold(),is(31));
-        assertThat(columnFamily1.getMinCompactionThreshold(),is(3));
-        assertThat(columnFamily1.getReadRepairChance(),is(0.1d));
-        assertThat(columnFamily1.getReplicationOnWrite(),is(Boolean.FALSE));
+		assertThat(columnFamily1.getComment(), is("amazing comment"));
+		assertThat(columnFamily1.getCompactionStrategy(), is("LeveledCompactionStrategy"));
+		assertThat(columnFamily1.getCompactionStrategyOptions().get(0).getName(), is("sstable_size_in_mb"));
+		assertThat(columnFamily1.getCompactionStrategyOptions().get(0).getValue(), is("10"));
+		assertThat(columnFamily1.getGcGraceSeconds(), is(9999));
+		assertThat(columnFamily1.getMaxCompactionThreshold(), is(31));
+		assertThat(columnFamily1.getMinCompactionThreshold(), is(3));
+		assertThat(columnFamily1.getReadRepairChance(), is(0.1d));
+		assertThat(columnFamily1.getReplicationOnWrite(), is(Boolean.FALSE));
 
 		assertThat(columnFamily1.getRows(), notNullValue());
 		assertThat(columnFamily1.getRows().size(), is(1));
 		assertThat(columnFamily1.getRows().get(0), notNullValue());
 		assertThat(columnFamily1.getRows().get(0).getKey().getValue(), is("key01"));
-		assertThat(columnFamily1.getRows().get(0).getKey().getType(),
-				is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(columnFamily1.getRows().get(0).getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 		assertThat(columnFamily1.getRows().get(0).getColumns(), notNullValue());
 		assertThat(columnFamily1.getRows().get(0).getColumns().size(), is(1));
 		assertThat(columnFamily1.getRows().get(0).getColumns().get(0), notNullValue());
-		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getName().getValue(),
-				is("columnName1"));
-		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getName().getType(),
-				is(GenericTypeEnum.UTF_8_TYPE));
-		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getValue().getValue(),
-				is("columnValue1"));
-		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getValue().getType(),
-				is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getName().getValue(), is("columnName1"));
+		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getValue().getValue(), is("columnValue1"));
+		assertThat(columnFamily1.getRows().get(0).getColumns().get(0).getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 
 		assertThat(dataSet.getColumnFamilies().get(1), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(1).getName(), is("columnFamily2"));
-		assertThat(dataSet.getColumnFamilies().get(1).getKeyType().getTypeName(),
-				is(ComparatorType.UTF8TYPE.getTypeName()));
-		assertThat(dataSet.getColumnFamilies().get(1).getComparatorType().getTypeName(),
-				is(ComparatorType.UTF8TYPE.getTypeName()));
-		assertThat(dataSet.getColumnFamilies().get(1).getSubComparatorType().getTypeName(),
-				is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(dataSet.getColumnFamilies().get(1).getKeyType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(dataSet.getColumnFamilies().get(1).getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(dataSet.getColumnFamilies().get(1).getSubComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
 
 		assertThat(dataSet.getColumnFamilies().get(1).getRows(), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getKey().getValue(), is("key02"));
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getKey().getType(),
-				is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getColumns(), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getColumns().isEmpty(), is(true));
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns(), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0), notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getName().getValue(),
-				is("superColumnName2"));
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getName().getType(),
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getName().getValue(), is("superColumnName2"));
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns(), notNullValue());
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().size(), is(1));
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0), notNullValue());
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0).getName().getValue(), is("columnName2"));
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0).getName().getType(),
 				is(GenericTypeEnum.UTF_8_TYPE));
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns(),
-				notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().size(),
-				is(1));
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0),
-				notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0)
-				.getName().getValue(), is("columnName2"));
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0)
-				.getName().getType(), is(GenericTypeEnum.UTF_8_TYPE));
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0)
-				.getValue().getValue(), is("2"));
-		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0)
-				.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0).getValue().getValue(), is("2"));
+		assertThat(dataSet.getColumnFamilies().get(1).getRows().get(0).getSuperColumns().get(0).getColumns().get(0).getValue().getType(),
+				is(GenericTypeEnum.LONG_TYPE));
 
 	}
 
@@ -236,17 +214,13 @@ public class ClasspathYamlDataSetTest {
 		assertThat(dataSet.getColumnFamilies().get(2).getRows().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getKey().getValue(), is("key10"));
-		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getKey().getType(),
-				is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns(), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().get(0), notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().get(0).getName().getValue(),
-				is("columnName11"));
-		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().get(0).getValue().getValue(),
-				is("11"));
-		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().get(0).getValue().getType(),
-				is(GenericTypeEnum.COUNTER_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().get(0).getName().getValue(), is("columnName11"));
+		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().get(0).getValue().getValue(), is("11"));
+		assertThat(dataSet.getColumnFamilies().get(2).getRows().get(0).getColumns().get(0).getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
 	}
 
 	@Test
@@ -258,25 +232,18 @@ public class ClasspathYamlDataSetTest {
 		assertThat(dataSet.getColumnFamilies().get(3).getRows().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getKey().getValue(), is("key10"));
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getKey().getType(),
-				is(GenericTypeEnum.UTF_8_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getKey().getType(), is(GenericTypeEnum.UTF_8_TYPE));
 		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns(), notNullValue());
 		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().size(), is(1));
 		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0), notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getName().getValue(),
-				is("superColumnName11"));
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns(),
-				notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().size(),
-				is(1));
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0),
-				notNullValue());
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0)
-				.getName().getValue(), is("columnName111"));
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0)
-				.getValue().getValue(), is("111"));
-		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0)
-				.getValue().getType(), is(GenericTypeEnum.COUNTER_TYPE));
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getName().getValue(), is("superColumnName11"));
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns(), notNullValue());
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().size(), is(1));
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0), notNullValue());
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0).getName().getValue(), is("columnName111"));
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0).getValue().getValue(), is("111"));
+		assertThat(dataSet.getColumnFamilies().get(3).getRows().get(0).getSuperColumns().get(0).getColumns().get(0).getValue().getType(),
+				is(GenericTypeEnum.COUNTER_TYPE));
 	}
 
 	@Test(expected = ParseException.class)
@@ -289,26 +256,19 @@ public class ClasspathYamlDataSetTest {
 	public void shouldGetAColumnFamilyWithSecondaryIndex() {
 		DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithSecondaryIndex.yaml");
 
-		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0).getColumnName().getValue(),
-				is("columnWithIndexAndUTF8ValidationClass"));
-		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0).getColumnIndexType(),
-				is(ColumnIndexType.KEYS));
-		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0).getValidationClass(),
-				is(ComparatorType.UTF8TYPE));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0).getColumnName().getValue(), is("columnWithIndexAndUTF8ValidationClass"));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0).getColumnIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0).getValidationClass(), is(ComparatorType.UTF8TYPE));
 
-        assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getColumnName().getValue(),
-                is("columnWithIndexAndIndexNameAndUTF8ValidationClass"));
-        assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getColumnIndexType(),
-                is(ColumnIndexType.KEYS));
-        assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getValidationClass(),
-                is(ComparatorType.UTF8TYPE));
-        assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getIndexName(),is("indexNameOfTheIndex"));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getColumnName().getValue(),
+				is("columnWithIndexAndIndexNameAndUTF8ValidationClass"));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getColumnIndexType(), is(ColumnIndexType.KEYS));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getValidationClass(), is(ComparatorType.UTF8TYPE));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(1).getIndexName(), is("indexNameOfTheIndex"));
 
-		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2).getColumnName().getValue(),
-				is("columnWithUTF8ValidationClass"));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2).getColumnName().getValue(), is("columnWithUTF8ValidationClass"));
 		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2).getColumnIndexType(), nullValue());
-		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2).getValidationClass(),
-				is(ComparatorType.UTF8TYPE));
+		assertThat(dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(2).getValidationClass(), is(ComparatorType.UTF8TYPE));
 	}
 
 	@Test
@@ -323,45 +283,113 @@ public class ClasspathYamlDataSetTest {
 		dataSet.getKeyspace();
 	}
 
-    @Test
-    public void shouldGetAColumnFamilyWithNullColumnValue() {
-        DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithNullColumnValue.yaml");
-        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamilyModel.getName(), is("columnFamilyWithNullColumnValue"));
-        ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
-        assertThat(columnModel.getName().getValue(), is("columnWithNullColumnValue"));
-        assertThat(columnModel.getValue(), nullValue());
-    }
-   @Test
-   public void shouldGetAColumnFamilyWithTimestampedColumn() {
-       DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithTimestamp.yaml");
-       ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-       assertThat(columnFamilyModel.getName(), is("columnFamilyWithTimestampedColumn"));
-       ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
-       assertThat(columnModel.getName().getValue(), is("columnWithTimestamp"));
-       assertThat(columnModel.getTimestamp(), is(2020L));
-   }
+	@Test
+	public void shouldGetAColumnFamilyWithNullColumnValue() {
+		DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithNullColumnValue.yaml");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithNullColumnValue"));
+		ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
+		assertThat(columnModel.getName().getValue(), is("columnWithNullColumnValue"));
+		assertThat(columnModel.getValue(), nullValue());
+	}
 
-    @Test
-    public void shouldGetAColumnFamilyWithMetadataAndFunction() {
-        DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithMetadataAndFunctions.yaml");
-        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
-        assertThat(columnFamilyModel.getName(), is("columnFamilyWithMetadata"));
-        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
-        ColumnModel column1 = columns.get(0);
-        assertThat(column1.getName().getValue(),is("column1"));
-        assertThat(column1.getValue().getValue(),is("1"));
-        assertThat(column1.getValue().getType(),is(GenericTypeEnum.LONG_TYPE));
+	@Test
+	public void shouldGetAColumnFamilyWithTimestampedColumn() {
+		DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithTimestamp.yaml");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithTimestampedColumn"));
+		ColumnModel columnModel = columnFamilyModel.getRows().get(0).getColumns().get(0);
+		assertThat(columnModel.getName().getValue(), is("columnWithTimestamp"));
+		assertThat(columnModel.getTimestamp(), is(2020L));
+	}
 
-        ColumnModel column2 = columns.get(1);
-        assertThat(column2.getName().getValue(),is("column2"));
-        assertThat(column2.getValue().getValue(),is("2"));
-        assertThat(column2.getValue().getType(),is(GenericTypeEnum.LONG_TYPE));
+	@Test
+	public void shouldGetAColumnFamilyWithMetadataAndFunction() {
+		DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithMetadataAndFunctions.yaml");
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithMetadata"));
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+		ColumnModel column1 = columns.get(0);
+		assertThat(column1.getName().getValue(), is("column1"));
+		assertThat(column1.getValue().getValue(), is("1"));
+		assertThat(column1.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
 
-        ColumnModel column3 = columns.get(2);
-        assertThat(column3.getName().getValue(),is("column3"));
-        assertThat(column3.getValue().getValue(),is("value3"));
-        assertThat(column3.getValue().getType(),is(GenericTypeEnum.UTF_8_TYPE));
-    }
+		ColumnModel column2 = columns.get(1);
+		assertThat(column2.getName().getValue(), is("column2"));
+		assertThat(column2.getValue().getValue(), is("2"));
+		assertThat(column2.getValue().getType(), is(GenericTypeEnum.LONG_TYPE));
 
+		ColumnModel column3 = columns.get(2);
+		assertThat(column3.getName().getValue(), is("column3"));
+		assertThat(column3.getValue().getValue(), is("value3"));
+		assertThat(column3.getValue().getType(), is(GenericTypeEnum.UTF_8_TYPE));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithColumnsInReverseOrder() {
+		DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithReversedComparatorOnSimpleType.yaml");
+
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnSimpleType"));
+		assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+		assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(reversed=true)"));
+
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+		ColumnModel column1 = columns.get(0);
+		assertThat(column1.getName().getValue(), is("c"));
+		assertThat(column1.getValue().getValue(), is("c"));
+
+		ColumnModel column2 = columns.get(1);
+		assertThat(column2.getName().getValue(), is("b"));
+		assertThat(column2.getValue().getValue(), is("b"));
+
+		ColumnModel column3 = columns.get(2);
+		assertThat(column3.getName().getValue(), is("a"));
+		assertThat(column3.getValue().getValue(), is("a"));
+	}
+
+	@Test
+	public void shouldGetAColumnFamilyWithCompositeColumnsInReverseOrder() {
+		DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithReversedComparatorOnCompositeTypes.yaml");
+
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnCompositeTypes"));
+		assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.COMPOSITETYPE.getTypeName()));
+		assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))"));
+
+		GenericTypeEnum[] expecTedTypesBelongingCompositeType = new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE };
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+		assertThat(columns.get(0).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(0).getName().getCompositeValues(), is(new String[] { "12", "aa", "11" }));
+		assertThat(columns.get(0).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(0).getValue().getValue(), is("v6"));
+
+		assertThat(columns.get(1).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(1).getName().getCompositeValues(), is(new String[] { "12", "ab", "12" }));
+		assertThat(columns.get(1).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(1).getValue().getValue(), is("v5"));
+
+		assertThat(columns.get(2).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(2).getName().getCompositeValues(), is(new String[] { "12", "ab", "11" }));
+		assertThat(columns.get(2).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(2).getValue().getValue(), is("v4"));
+
+		assertThat(columns.get(3).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(3).getName().getCompositeValues(), is(new String[] { "11", "aa", "11" }));
+		assertThat(columns.get(3).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(3).getValue().getValue(), is("v3"));
+
+		assertThat(columns.get(4).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(4).getName().getCompositeValues(), is(new String[] { "11", "ab", "12" }));
+		assertThat(columns.get(4).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(4).getValue().getValue(), is("v2"));
+
+		assertThat(columns.get(5).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(5).getName().getCompositeValues(), is(new String[] { "11", "ab", "11" }));
+		assertThat(columns.get(5).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+		assertThat(columns.get(5).getValue().getValue(), is("v1"));
+	}
 }

--- a/src/test/java/org/cassandraunit/integration/ReversedComparatorWithCompositeTypesTest.java
+++ b/src/test/java/org/cassandraunit/integration/ReversedComparatorWithCompositeTypesTest.java
@@ -1,0 +1,148 @@
+package org.cassandraunit.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import me.prettyprint.cassandra.serializers.CompositeSerializer;
+import me.prettyprint.cassandra.serializers.IntegerSerializer;
+import me.prettyprint.cassandra.serializers.LongSerializer;
+import me.prettyprint.cassandra.serializers.StringSerializer;
+import me.prettyprint.cassandra.service.CassandraHostConfigurator;
+import me.prettyprint.hector.api.Cluster;
+import me.prettyprint.hector.api.Keyspace;
+import me.prettyprint.hector.api.beans.Composite;
+import me.prettyprint.hector.api.beans.HColumn;
+import me.prettyprint.hector.api.beans.OrderedRows;
+import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
+import me.prettyprint.hector.api.ddl.ComparatorType;
+import me.prettyprint.hector.api.factory.HFactory;
+import me.prettyprint.hector.api.mutation.Mutator;
+import me.prettyprint.hector.api.query.QueryResult;
+import me.prettyprint.hector.api.query.RangeSlicesQuery;
+
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.cassandraunit.DataLoader;
+import org.cassandraunit.dataset.yaml.ClassPathYamlDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReversedComparatorWithCompositeTypesTest {
+	private static final String KEYSPACE_NAME = "reversedKeyspace";
+	private static final String ROW_KEY = "row1";
+
+	private static final CompositeSerializer cs = CompositeSerializer.get();
+	private static final StringSerializer ss = StringSerializer.get();
+
+	@Before
+	public void before() throws Exception {
+		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+		DataLoader dataLoader = new DataLoader("TestCluster", "localhost:9171");
+		dataLoader.load(new ClassPathYamlDataSet("integration/emptyDataSetWithReversedComparatorOnCompositeTypes.yaml"));
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingCassandraUnit() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "columnFamilyWithReversedComparatorOnCompTypes";
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, Composite, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingHector() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "manuallyCreated";
+		createColumnFamily(cluster, columnFamily);
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, Composite, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	private void createColumnFamily(final Cluster cluster, final String columnFamily) {
+		final ColumnFamilyDefinition cfd = HFactory.createColumnFamilyDefinition(KEYSPACE_NAME, columnFamily, ComparatorType.COMPOSITETYPE);
+		cfd.setComparatorTypeAlias("(LongType(reversed=true),IntegerType,UTF8Type(reversed=true))");
+		cfd.setKeyValidationClass(UTF8Type.class.getName());
+		cfd.setDefaultValidationClass(UTF8Type.class.getName());
+		cluster.addColumnFamily(cfd, true);
+	}
+
+	private void writeDataSet(final Keyspace keyspace, final String columnFamily) {
+		final Mutator<String> mutator = HFactory.createMutator(keyspace, ss);
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 1, "a"), "v1", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 1, "b"), "v2", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 1, "c"), "v3", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 2, "a"), "v4", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 2, "b"), "v5", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 2, "c"), "v6", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(2, 1, "a"), "v7", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(2, 1, "b"), "v8", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(2, 1, "c"), "v9", cs, ss));
+		mutator.execute();
+	}
+
+	private Composite getName(final long i, final int j, final String string) {
+		final Composite composite = new Composite();
+		composite.addComponent(i, LongSerializer.get());
+		composite.addComponent(j, IntegerSerializer.get());
+		composite.addComponent(string, StringSerializer.get());
+		return composite;
+	}
+
+	private QueryResult<OrderedRows<String, Composite, String>> readDataSet(final Keyspace keyspace, final String columnFamily) {
+		final RangeSlicesQuery<String, Composite, String> query = HFactory.createRangeSlicesQuery(keyspace, ss, cs, ss);
+		query.setColumnFamily(columnFamily);
+		query.setRange(null, null, false, Integer.MAX_VALUE);
+		QueryResult<OrderedRows<String, Composite, String>> results = query.execute();
+		return results;
+	}
+
+	private void assertResultsAreSortedAccordingToComparator(QueryResult<OrderedRows<String, Composite, String>> results) {
+		assertNotNull(results);
+		assertNotNull(results.get());
+		assertNotNull(results.get().getList());
+		assertEquals(1, results.get().getList().size());
+		assertNotNull(results.get().getList().get(0));
+		assertEquals(ROW_KEY, results.get().getList().get(0).getKey());
+		assertNotNull(results.get().getList().get(0).getColumnSlice());
+
+		final List<HColumn<Composite, String>> columns = results.get().getList().get(0).getColumnSlice().getColumns();
+		assertNotNull(columns);
+
+		// assertEquals(getName(2, 1, "c"), columns.get(0).getName());
+		assertEquals("v9", columns.get(0).getValue());
+
+		// assertEquals(getName(2, 1, "b"), columns.get(1).getName());
+		assertEquals("v8", columns.get(1).getValue());
+
+		// assertEquals(getName(2, 1, "a"), columns.get(2).getName());
+		assertEquals("v7", columns.get(2).getValue());
+
+		// assertEquals(getName(1, 1, "c"), columns.get(3).getName());
+		assertEquals("v3", columns.get(3).getValue());
+
+		// assertEquals(getName(1, 1, "b"), columns.get(4).getName());
+		assertEquals("v2", columns.get(4).getValue());
+
+		// assertEquals(getName(1, 1, "a"), columns.get(5).getName());
+		assertEquals("v1", columns.get(5).getValue());
+
+		// assertEquals(getName(1, 2, "c"), columns.get(6).getName());
+		assertEquals("v6", columns.get(6).getValue());
+
+		// assertEquals(getName(1, 2, "b"), columns.get(7).getName());
+		assertEquals("v5", columns.get(7).getValue());
+
+		// assertEquals(getName(1, 2, "a"), columns.get(8).getName());
+		assertEquals("v4", columns.get(8).getValue());
+	}
+}

--- a/src/test/java/org/cassandraunit/integration/ReversedComparatorWithSimpleTypeTest.java
+++ b/src/test/java/org/cassandraunit/integration/ReversedComparatorWithSimpleTypeTest.java
@@ -1,0 +1,110 @@
+package org.cassandraunit.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import me.prettyprint.cassandra.serializers.StringSerializer;
+import me.prettyprint.cassandra.service.CassandraHostConfigurator;
+import me.prettyprint.hector.api.Cluster;
+import me.prettyprint.hector.api.Keyspace;
+import me.prettyprint.hector.api.beans.HColumn;
+import me.prettyprint.hector.api.beans.OrderedRows;
+import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
+import me.prettyprint.hector.api.ddl.ComparatorType;
+import me.prettyprint.hector.api.factory.HFactory;
+import me.prettyprint.hector.api.mutation.Mutator;
+import me.prettyprint.hector.api.query.QueryResult;
+import me.prettyprint.hector.api.query.RangeSlicesQuery;
+
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.cassandraunit.DataLoader;
+import org.cassandraunit.dataset.yaml.ClassPathYamlDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReversedComparatorWithSimpleTypeTest {
+	private static final String KEYSPACE_NAME = "reversedKeyspace";
+	private static final String ROW_KEY = "row1";
+
+	@Before
+	public void before() throws Exception {
+		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+		DataLoader dataLoader = new DataLoader("TestCluster", "localhost:9171");
+		dataLoader.load(new ClassPathYamlDataSet("integration/emptyDataSetWithReversedComparatorOnSimpleType.yaml"));
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingCassandraUnit() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "columnFamilyWithReversedComparatorOnSimpleType";
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, String, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingHector() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "manuallyCreated";
+		createColumnFamily(cluster, columnFamily);
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, String, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	private void createColumnFamily(final Cluster cluster, final String columnFamily) {
+		final ColumnFamilyDefinition cfd = HFactory.createColumnFamilyDefinition(KEYSPACE_NAME, columnFamily, ComparatorType.UTF8TYPE);
+		cfd.setComparatorTypeAlias("(reversed=true)");
+		cfd.setKeyValidationClass(UTF8Type.class.getName());
+		cfd.setDefaultValidationClass(UTF8Type.class.getName());
+		cluster.addColumnFamily(cfd, true);
+	}
+
+	private void writeDataSet(final Keyspace keyspace, final String columnFamily) {
+		final Mutator<String> mutator = HFactory.createMutator(keyspace, StringSerializer.get());
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createStringColumn("a", "v1"));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createStringColumn("b", "v2"));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createStringColumn("c", "v3"));
+		mutator.execute();
+	}
+
+	private QueryResult<OrderedRows<String, String, String>> readDataSet(final Keyspace keyspace, final String columnFamily) {
+		final StringSerializer ss = StringSerializer.get();
+		final RangeSlicesQuery<String, String, String> query = HFactory.createRangeSlicesQuery(keyspace, ss, ss, ss);
+		query.setColumnFamily(columnFamily);
+		query.setRange(null, null, false, Integer.MAX_VALUE);
+		QueryResult<OrderedRows<String, String, String>> results = query.execute();
+		return results;
+	}
+
+	private void assertResultsAreSortedAccordingToComparator(QueryResult<OrderedRows<String, String, String>> results) {
+		assertNotNull(results);
+		assertNotNull(results.get());
+		assertNotNull(results.get().getList());
+		assertEquals(1, results.get().getList().size());
+		assertNotNull(results.get().getList().get(0));
+		assertEquals(ROW_KEY, results.get().getList().get(0).getKey());
+		assertNotNull(results.get().getList().get(0).getColumnSlice());
+
+		final List<HColumn<String, String>> columns = results.get().getList().get(0).getColumnSlice().getColumns();
+		assertNotNull(columns);
+
+		assertEquals("c", columns.get(0).getName());
+		assertEquals("v3", columns.get(0).getValue());
+
+		assertEquals("b", columns.get(1).getName());
+		assertEquals("v2", columns.get(1).getValue());
+
+		assertEquals("a", columns.get(2).getName());
+		assertEquals("v1", columns.get(2).getValue());
+	}
+}

--- a/src/test/java/org/cassandraunit/utils/ComparatorTypeHelperTest.java
+++ b/src/test/java/org/cassandraunit/utils/ComparatorTypeHelperTest.java
@@ -3,6 +3,7 @@ package org.cassandraunit.utils;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import me.prettyprint.hector.api.ddl.ComparatorType;
 
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.type.GenericTypeEnum;
@@ -55,9 +56,25 @@ public class ComparatorTypeHelperTest {
 
 	@Test
 	public void shouldExtractGenericTypesFromTypeAlias() throws Exception {
-		GenericTypeEnum[] genericTypesEnum = ComparatorTypeHelper
-				.extractGenericTypesFromTypeAlias("(LongType,UTF8Type,IntegerType)");
-		assertThat(genericTypesEnum, is(new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
-				GenericTypeEnum.INTEGER_TYPE }));
+		GenericTypeEnum[] genericTypesEnum = ComparatorTypeHelper.extractGenericTypesFromTypeAlias("(LongType,UTF8Type,IntegerType)");
+		assertThat(genericTypesEnum, is(new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE }));
+	}
+
+	@Test
+	public void shouldExtractReversedType() {
+		ComparatorType typeWithReversedTrue = ComparatorTypeHelper.verifyAndExtract("UTF8Type(reversed=true)");
+		assertThat(typeWithReversedTrue, is(ComparatorType.UTF8TYPE));
+
+		ComparatorType typeWithReversedFalse = ComparatorTypeHelper.verifyAndExtract("UTF8Type(reversed=false)");
+		assertThat(typeWithReversedFalse, is(ComparatorType.UTF8TYPE));
+	}
+
+	@Test
+	public void shouldExtractReversedTrueCompositeType() {
+		ComparatorType typesWithReversedTrue = ComparatorTypeHelper.verifyAndExtract("CompositeType(LongType(reversed=true),UTF8Type)");
+		assertThat(typesWithReversedTrue, is(ComparatorType.COMPOSITETYPE));
+
+		ComparatorType typesWithReversedFalse = ComparatorTypeHelper.verifyAndExtract("CompositeType(LongType(reversed=false),UTF8Type)");
+		assertThat(typesWithReversedFalse, is(ComparatorType.COMPOSITETYPE));
 	}
 }

--- a/src/test/java/org/cassandraunit/utils/MockDataSetHelper.java
+++ b/src/test/java/org/cassandraunit/utils/MockDataSetHelper.java
@@ -1,8 +1,15 @@
 package org.cassandraunit.utils;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import me.prettyprint.hector.api.ddl.ColumnIndexType;
 import me.prettyprint.hector.api.ddl.ColumnType;
 import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.model.ColumnFamilyModel;
 import org.cassandraunit.model.ColumnMetadataModel;
@@ -14,12 +21,6 @@ import org.cassandraunit.model.StrategyModel;
 import org.cassandraunit.model.SuperColumnModel;
 import org.cassandraunit.type.GenericType;
 import org.cassandraunit.type.GenericTypeEnum;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * 
@@ -110,17 +111,16 @@ public class MockDataSetHelper {
 		beautifulColumnFamily.setSubComparatorType(ComparatorType.LONGTYPE);
 		beautifulColumnFamily.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
 
-        beautifulColumnFamily.setComment("amazing comment");
-        beautifulColumnFamily.setCompactionStrategy("LeveledCompactionStrategy");
-        List<CompactionStrategyOptionModel> compactionStrategyOptions = new ArrayList<CompactionStrategyOptionModel>();
-        compactionStrategyOptions.add(new CompactionStrategyOptionModel("sstable_size_in_mb", "10"));
-        beautifulColumnFamily.setCompactionStrategyOptions(compactionStrategyOptions);
-        beautifulColumnFamily.setGcGraceSeconds(9999);
-        beautifulColumnFamily.setMaxCompactionThreshold(31);
-        beautifulColumnFamily.setMinCompactionThreshold(3);
-        beautifulColumnFamily.setReadRepairChance(0.1d);
-        beautifulColumnFamily.setReplicationOnWrite(Boolean.FALSE);
-
+		beautifulColumnFamily.setComment("amazing comment");
+		beautifulColumnFamily.setCompactionStrategy("LeveledCompactionStrategy");
+		List<CompactionStrategyOptionModel> compactionStrategyOptions = new ArrayList<CompactionStrategyOptionModel>();
+		compactionStrategyOptions.add(new CompactionStrategyOptionModel("sstable_size_in_mb", "10"));
+		beautifulColumnFamily.setCompactionStrategyOptions(compactionStrategyOptions);
+		beautifulColumnFamily.setGcGraceSeconds(9999);
+		beautifulColumnFamily.setMaxCompactionThreshold(31);
+		beautifulColumnFamily.setMinCompactionThreshold(3);
+		beautifulColumnFamily.setReadRepairChance(0.1d);
+		beautifulColumnFamily.setReplicationOnWrite(Boolean.FALSE);
 
 		List<RowModel> rows = new ArrayList<RowModel>();
 
@@ -165,35 +165,33 @@ public class MockDataSetHelper {
 		columnFamily3.setKeyType(ComparatorType.UTF8TYPE);
 		columnFamily3.setComparatorType(ComparatorType.UTF8TYPE);
 		columnFamily3.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
-		columnFamily3.addColumnMetadata(new ColumnMetadataModel(
-                newUtf8GenericType("columnWithSecondaryIndexAndValidationClassAsLongType"), ComparatorType.LONGTYPE, ColumnIndexType.KEYS, null));
+		columnFamily3.addColumnMetadata(new ColumnMetadataModel(newUtf8GenericType("columnWithSecondaryIndexAndValidationClassAsLongType"),
+				ComparatorType.LONGTYPE, ColumnIndexType.KEYS, null));
 		columnFamilies.add(columnFamily3);
 
-        /* column family 4 with index */
-        ColumnFamilyModel columnFamily4 = new ColumnFamilyModel();
-        columnFamily4.setName("columnFamilyWithSecondaryIndexAndIndexName");
-        columnFamily4.setType(ColumnType.STANDARD);
-        columnFamily4.setKeyType(ComparatorType.UTF8TYPE);
-        columnFamily4.setComparatorType(ComparatorType.UTF8TYPE);
-        columnFamily4.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
-        columnFamily4.addColumnMetadata(new ColumnMetadataModel(
-                newUtf8GenericType("columnWithSecondaryIndexAndValidationClassAsUTF8Type"), ComparatorType.UTF8TYPE, ColumnIndexType.KEYS,
-                "columnWithSecondaryIndexHaveIndexNameAndValidationClassAsUTF8Type"));
+		/* column family 4 with index */
+		ColumnFamilyModel columnFamily4 = new ColumnFamilyModel();
+		columnFamily4.setName("columnFamilyWithSecondaryIndexAndIndexName");
+		columnFamily4.setType(ColumnType.STANDARD);
+		columnFamily4.setKeyType(ComparatorType.UTF8TYPE);
+		columnFamily4.setComparatorType(ComparatorType.UTF8TYPE);
+		columnFamily4.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
+		columnFamily4.addColumnMetadata(new ColumnMetadataModel(newUtf8GenericType("columnWithSecondaryIndexAndValidationClassAsUTF8Type"),
+				ComparatorType.UTF8TYPE, ColumnIndexType.KEYS, "columnWithSecondaryIndexHaveIndexNameAndValidationClassAsUTF8Type"));
 
-        columnFamilies.add(columnFamily4);
+		columnFamilies.add(columnFamily4);
 
-        /* column family 5 with column validation class */
-        ColumnFamilyModel columnFamily5 = new ColumnFamilyModel();
-        columnFamily5.setName("columnFamilyWithColumnValidationClass");
-        columnFamily5.setType(ColumnType.STANDARD);
-        columnFamily5.setKeyType(ComparatorType.UTF8TYPE);
-        columnFamily5.setComparatorType(ComparatorType.UTF8TYPE);
-        columnFamily5.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
-        columnFamily5.addColumnMetadata(new ColumnMetadataModel(
-                newUtf8GenericType("columnWithValidationClassAsUTF8Type"),
-                ComparatorType.UTF8TYPE, null, null));
+		/* column family 5 with column validation class */
+		ColumnFamilyModel columnFamily5 = new ColumnFamilyModel();
+		columnFamily5.setName("columnFamilyWithColumnValidationClass");
+		columnFamily5.setType(ColumnType.STANDARD);
+		columnFamily5.setKeyType(ComparatorType.UTF8TYPE);
+		columnFamily5.setComparatorType(ComparatorType.UTF8TYPE);
+		columnFamily5.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
+		columnFamily5
+				.addColumnMetadata(new ColumnMetadataModel(newUtf8GenericType("columnWithValidationClassAsUTF8Type"), ComparatorType.UTF8TYPE, null, null));
 
-        columnFamilies.add(columnFamily5);
+		columnFamilies.add(columnFamily5);
 
 		keyspace.setColumnFamilies(columnFamilies);
 
@@ -202,11 +200,11 @@ public class MockDataSetHelper {
 		return mockDataSet;
 	}
 
-    private static GenericType newUtf8GenericType(String value) {
-        return new GenericType(value, GenericTypeEnum.UTF_8_TYPE);
-    }
+	private static GenericType newUtf8GenericType(String value) {
+		return new GenericType(value, GenericTypeEnum.UTF_8_TYPE);
+	}
 
-    private static SuperColumnModel constructDefinedSuperColumnForMock(int columnNumber) {
+	private static SuperColumnModel constructDefinedSuperColumnForMock(int columnNumber) {
 		SuperColumnModel superColumnModel = new SuperColumnModel();
 		superColumnModel.setName(new GenericType("name" + columnNumber, GenericTypeEnum.UTF_8_TYPE));
 		List<ColumnModel> columns = new ArrayList<ColumnModel>();
@@ -376,13 +374,11 @@ public class MockDataSetHelper {
 		row1.setKey(new GenericType("13816710-1dd2-11b2-879a-782bcb80ff6a", GenericTypeEnum.UUID_TYPE));
 		List<ColumnModel> columns1 = new ArrayList<ColumnModel>();
 		ColumnModel columnModel11 = new ColumnModel();
-		columnModel11
-				.setName(new GenericType("13816710-1dd2-11b2-879a-782bcb80ff6a", GenericTypeEnum.LEXICAL_UUID_TYPE));
+		columnModel11.setName(new GenericType("13816710-1dd2-11b2-879a-782bcb80ff6a", GenericTypeEnum.LEXICAL_UUID_TYPE));
 		columnModel11.setValue(new GenericType("11", GenericTypeEnum.BYTES_TYPE));
 		columns1.add(columnModel11);
 		ColumnModel columnModel12 = new ColumnModel();
-		columnModel12
-				.setName(new GenericType("13818e20-1dd2-11b2-879a-782bcb80ff6a", GenericTypeEnum.LEXICAL_UUID_TYPE));
+		columnModel12.setName(new GenericType("13818e20-1dd2-11b2-879a-782bcb80ff6a", GenericTypeEnum.LEXICAL_UUID_TYPE));
 		columnModel12.setValue(new GenericType("12", GenericTypeEnum.BYTES_TYPE));
 		columns1.add(columnModel12);
 		row1.setColumns(columns1);
@@ -581,43 +577,43 @@ public class MockDataSetHelper {
 
 		/* column1 */
 		ColumnModel column1 = new ColumnModel();
-		column1.setName(new GenericType(new String[] { "11", "aa", "11" }, new GenericTypeEnum[] {
-				GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE }));
+		column1.setName(new GenericType(new String[] { "11", "aa", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
 		column1.setValue(new GenericType("v1", GenericTypeEnum.UTF_8_TYPE));
 		row.getColumns().add(column1);
 
 		/* column2 */
 		ColumnModel column2 = new ColumnModel();
-		column2.setName(new GenericType(new String[] { "11", "ab", "11" }, new GenericTypeEnum[] {
-				GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE }));
+		column2.setName(new GenericType(new String[] { "11", "ab", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
 		column2.setValue(new GenericType("v2", GenericTypeEnum.UTF_8_TYPE));
 		row.getColumns().add(column2);
 
 		/* column3 */
 		ColumnModel column3 = new ColumnModel();
-		column3.setName(new GenericType(new String[] { "11", "ab", "12" }, new GenericTypeEnum[] {
-				GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE }));
+		column3.setName(new GenericType(new String[] { "11", "ab", "12" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
 		column3.setValue(new GenericType("v3", GenericTypeEnum.UTF_8_TYPE));
 		row.getColumns().add(column3);
 
 		/* column4 */
 		ColumnModel column4 = new ColumnModel();
-		column4.setName(new GenericType(new String[] { "12", "aa", "11" }, new GenericTypeEnum[] {
-				GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE }));
+		column4.setName(new GenericType(new String[] { "12", "aa", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
 		column4.setValue(new GenericType("v4", GenericTypeEnum.UTF_8_TYPE));
 		row.getColumns().add(column4);
 
 		/* column5 */
 		ColumnModel column5 = new ColumnModel();
-		column5.setName(new GenericType(new String[] { "12", "ab", "11" }, new GenericTypeEnum[] {
-				GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE }));
+		column5.setName(new GenericType(new String[] { "12", "ab", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
 		column5.setValue(new GenericType("v5", GenericTypeEnum.UTF_8_TYPE));
 		row.getColumns().add(column5);
 
 		/* column6 */
 		ColumnModel column6 = new ColumnModel();
-		column6.setName(new GenericType(new String[] { "12", "zz", "12" }, new GenericTypeEnum[] {
-				GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE }));
+		column6.setName(new GenericType(new String[] { "12", "zz", "12" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
 		column6.setValue(new GenericType("v6", GenericTypeEnum.UTF_8_TYPE));
 		row.getColumns().add(column6);
 
@@ -634,8 +630,7 @@ public class MockDataSetHelper {
 
 		/* row1 */
 		RowModel row21 = new RowModel();
-		row21.setKey(new GenericType(new String[] { "12", "az" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE,
-				GenericTypeEnum.UTF_8_TYPE }));
+		row21.setKey(new GenericType(new String[] { "12", "az" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE }));
 
 		/* column1 */
 		ColumnModel column21 = new ColumnModel();
@@ -651,65 +646,176 @@ public class MockDataSetHelper {
 		return mockDataSet;
 	}
 
-    public static DataSet getMockDataSetWithNullColumnValue() {
-        DataSet mockDataSet = mock(DataSet.class);
-        KeyspaceModel keyspace = new KeyspaceModel();
-        keyspace.setName("keyspaceWithNullColumnValue");
-        keyspace.getColumnFamilies();
+	public static DataSet getMockDataSetWithNullColumnValue() {
+		DataSet mockDataSet = mock(DataSet.class);
+		KeyspaceModel keyspace = new KeyspaceModel();
+		keyspace.setName("keyspaceWithNullColumnValue");
+		keyspace.getColumnFamilies();
 
-        /* column family */
-        ColumnFamilyModel columnFamily = new ColumnFamilyModel();
-        columnFamily.setName("columnFamilyWithNullColumnValue");
-        columnFamily.setKeyType(ComparatorType.UTF8TYPE);
-        columnFamily.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
+		/* column family */
+		ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+		columnFamily.setName("columnFamilyWithNullColumnValue");
+		columnFamily.setKeyType(ComparatorType.UTF8TYPE);
+		columnFamily.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
 
-        /* row1 */
-        RowModel row = new RowModel();
-        row.setKey(new GenericType("rowWithNullColumnValue", GenericTypeEnum.UTF_8_TYPE));
+		/* row1 */
+		RowModel row = new RowModel();
+		row.setKey(new GenericType("rowWithNullColumnValue", GenericTypeEnum.UTF_8_TYPE));
 
-        /* column1 */
-        ColumnModel column1 = new ColumnModel();
-        column1.setName(new GenericType("columnWithNullValue",GenericTypeEnum.UTF_8_TYPE));
-        row.getColumns().add(column1);
+		/* column1 */
+		ColumnModel column1 = new ColumnModel();
+		column1.setName(new GenericType("columnWithNullValue", GenericTypeEnum.UTF_8_TYPE));
+		row.getColumns().add(column1);
 
-        columnFamily.getRows().add(row);
-        keyspace.getColumnFamilies().add(columnFamily);
+		columnFamily.getRows().add(row);
+		keyspace.getColumnFamilies().add(columnFamily);
 
-        when(mockDataSet.getKeyspace()).thenReturn(keyspace);
-        when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
+		when(mockDataSet.getKeyspace()).thenReturn(keyspace);
+		when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
 
-        return mockDataSet;
-    }
+		return mockDataSet;
+	}
 
-    public static DataSet getMockDataSetWithTimestampedColumn() {
-        DataSet mockDataSet = mock(DataSet.class);
-        KeyspaceModel keyspace = new KeyspaceModel();
-        keyspace.setName("keyspaceWithTimestampedColumn");
-        keyspace.getColumnFamilies();
+	public static DataSet getMockDataSetWithTimestampedColumn() {
+		DataSet mockDataSet = mock(DataSet.class);
+		KeyspaceModel keyspace = new KeyspaceModel();
+		keyspace.setName("keyspaceWithTimestampedColumn");
+		keyspace.getColumnFamilies();
 
-        /* column family */
-        ColumnFamilyModel columnFamily = new ColumnFamilyModel();
-        columnFamily.setName("columnFamilyWithTimestampedColumn");
-        columnFamily.setKeyType(ComparatorType.UTF8TYPE);
-        columnFamily.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
+		/* column family */
+		ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+		columnFamily.setName("columnFamilyWithTimestampedColumn");
+		columnFamily.setKeyType(ComparatorType.UTF8TYPE);
+		columnFamily.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
 
-        /* row1 */
-        RowModel row = new RowModel();
-        row.setKey(new GenericType("rowWithTimestampedColumn", GenericTypeEnum.UTF_8_TYPE));
+		/* row1 */
+		RowModel row = new RowModel();
+		row.setKey(new GenericType("rowWithTimestampedColumn", GenericTypeEnum.UTF_8_TYPE));
 
-        /* column1 */
-        ColumnModel column1 = new ColumnModel();
-        column1.setName(new GenericType("columnWithTimestamp",GenericTypeEnum.UTF_8_TYPE));
-        column1.setTimestamp(new Long(2020L));
-        row.getColumns().add(column1);
+		/* column1 */
+		ColumnModel column1 = new ColumnModel();
+		column1.setName(new GenericType("columnWithTimestamp", GenericTypeEnum.UTF_8_TYPE));
+		column1.setTimestamp(new Long(2020L));
+		row.getColumns().add(column1);
 
-        columnFamily.getRows().add(row);
-        keyspace.getColumnFamilies().add(columnFamily);
+		columnFamily.getRows().add(row);
+		keyspace.getColumnFamilies().add(columnFamily);
 
-        when(mockDataSet.getKeyspace()).thenReturn(keyspace);
-        when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
+		when(mockDataSet.getKeyspace()).thenReturn(keyspace);
+		when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
 
-        return mockDataSet;
-    }
+		return mockDataSet;
+	}
 
+	public static DataSet getMockDataSetWithReversedComparatorOnSimpleType() {
+		DataSet mockDataSet = mock(DataSet.class);
+		KeyspaceModel keyspace = new KeyspaceModel();
+		keyspace.setName("reversedKeyspace");
+		keyspace.getColumnFamilies();
+
+		/* column family */
+		ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+		columnFamily.setName("columnFamilyWithReversedComparatorOnSimpleType");
+		columnFamily.setKeyType(ComparatorType.UTF8TYPE);
+		columnFamily.setComparatorType(ComparatorType.UTF8TYPE);
+		columnFamily.setComparatorTypeAlias("(reversed=true)");
+		columnFamily.setDefaultColumnValueType(ComparatorType.BYTESTYPE);
+
+		/* row1 */
+		RowModel row1 = new RowModel();
+		row1.setKey(new GenericType("row1", GenericTypeEnum.UTF_8_TYPE));
+
+		/* column1 */
+		ColumnModel column1 = new ColumnModel();
+		column1.setName(new GenericType("c", GenericTypeEnum.UTF_8_TYPE));
+		column1.setValue(new GenericType("c", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column1);
+
+		/* column2 */
+		ColumnModel column2 = new ColumnModel();
+		column2.setName(new GenericType("b", GenericTypeEnum.UTF_8_TYPE));
+		column2.setValue(new GenericType("b", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column2);
+
+		/* column3 */
+		ColumnModel column3 = new ColumnModel();
+		column3.setName(new GenericType("a", GenericTypeEnum.UTF_8_TYPE));
+		column3.setValue(new GenericType("a", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column3);
+
+		columnFamily.getRows().add(row1);
+		keyspace.getColumnFamilies().add(columnFamily);
+		when(mockDataSet.getKeyspace()).thenReturn(keyspace);
+		when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
+
+		return mockDataSet;
+	}
+
+	public static DataSet getMockDataSetWithReversedComparatorOnCompositeTypes() {
+		DataSet mockDataSet = mock(DataSet.class);
+		KeyspaceModel keyspace = new KeyspaceModel();
+		keyspace.setName("reversedKeyspace");
+		keyspace.getColumnFamilies();
+
+		/* column family */
+		ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+		columnFamily.setName("columnFamilyWithReversedCompOnCompositeTypes");
+		columnFamily.setKeyType(ComparatorType.UTF8TYPE);
+		columnFamily.setComparatorType(ComparatorType.COMPOSITETYPE);
+		columnFamily.setComparatorTypeAlias("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))");
+		columnFamily.setDefaultColumnValueType(ComparatorType.BYTESTYPE);
+
+		/* row1 */
+		RowModel row1 = new RowModel();
+		row1.setKey(new GenericType("row1", GenericTypeEnum.UTF_8_TYPE));
+
+		/* column1 */
+		ColumnModel column1 = new ColumnModel();
+		column1.setName(new GenericType(new String[] { "12", "aa", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
+		column1.setValue(new GenericType("v6", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column1);
+
+		/* column2 */
+		ColumnModel column2 = new ColumnModel();
+		column2.setName(new GenericType(new String[] { "12", "ab", "12" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
+		column2.setValue(new GenericType("v5", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column2);
+
+		/* column3 */
+		ColumnModel column3 = new ColumnModel();
+		column3.setName(new GenericType(new String[] { "12", "ab", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
+		column3.setValue(new GenericType("v4", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column3);
+
+		/* column4 */
+		ColumnModel column4 = new ColumnModel();
+		column4.setName(new GenericType(new String[] { "11", "aa", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
+		column4.setValue(new GenericType("v3", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column4);
+
+		/* column5 */
+		ColumnModel column5 = new ColumnModel();
+		column5.setName(new GenericType(new String[] { "11", "ab", "12" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
+		column5.setValue(new GenericType("v2", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column5);
+
+		/* column6 */
+		ColumnModel column6 = new ColumnModel();
+		column6.setName(new GenericType(new String[] { "11", "ab", "11" }, new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+				GenericTypeEnum.INTEGER_TYPE }));
+		column6.setValue(new GenericType("v1", GenericTypeEnum.UTF_8_TYPE));
+		row1.getColumns().add(column6);
+
+		columnFamily.getRows().add(row1);
+		keyspace.getColumnFamilies().add(columnFamily);
+		when(mockDataSet.getKeyspace()).thenReturn(keyspace);
+		when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
+
+		return mockDataSet;
+	}
 }

--- a/src/test/resources/integration/emptyDataSetWithReversedComparatorOnCompositeTypes.yaml
+++ b/src/test/resources/integration/emptyDataSetWithReversedComparatorOnCompositeTypes.yaml
@@ -1,0 +1,4 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnCompTypes
+  comparatorType: CompositeType(LongType(reversed=true),IntegerType,UTF8Type(reversed=true))

--- a/src/test/resources/integration/emptyDataSetWithReversedComparatorOnSimpleType.yaml
+++ b/src/test/resources/integration/emptyDataSetWithReversedComparatorOnSimpleType.yaml
@@ -1,0 +1,4 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnSimpleType
+  comparatorType: UTF8Type(reversed=true)

--- a/src/test/resources/json/dataSetWithReversedComparatorOnCompositeTypes.json
+++ b/src/test/resources/json/dataSetWithReversedComparatorOnCompositeTypes.json
@@ -1,0 +1,34 @@
+{
+    "name" : "reversedKeyspace",
+	"columnFamilies" : [{
+        "name" : "columnFamilyWithReversedComparatorOnCompositeTypes",
+		"comparatorType" : "CompositeType(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))",
+        "rows" : [{
+            "key" : "row1",
+            "columns" : [{
+                "name" : "12:aa:11",
+                "value" : "v6"
+            },
+            {
+            	"name" : "12:ab:12",
+                "value" : "v5"
+            },
+             {
+            	"name" : "12:ab:11",
+                "value" : "v4"
+            },
+             {
+            	"name" : "11:aa:11",
+                "value" : "v3"
+            },
+             {
+            	"name" : "11:ab:12",
+                "value" : "v2"
+            },
+             {
+            	"name" : "11:ab:11",
+                "value" : "v1"
+            }]
+        }]
+    }]
+}

--- a/src/test/resources/json/dataSetWithReversedComparatorOnSimpleType.json
+++ b/src/test/resources/json/dataSetWithReversedComparatorOnSimpleType.json
@@ -1,0 +1,22 @@
+{
+    "name" : "reversedKeyspace",
+	"columnFamilies" : [{
+        "name" : "columnFamilyWithReversedComparatorOnSimpleType",
+		"comparatorType" : "UTF8Type(reversed=true)",
+        "rows" : [{
+            "key" : "row1",
+            "columns" : [{
+                "name" : "c",
+                "value" : "c"
+            },
+            {
+            	"name" : "b",
+                "value" : "b"
+            },
+             {
+            	"name" : "a",
+                "value" : "a"
+            }]
+        }]
+    }]
+}

--- a/src/test/resources/xml/dataSetWithReversedComparatorOnCompositeTypes.xml
+++ b/src/test/resources/xml/dataSetWithReversedComparatorOnCompositeTypes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<keyspace xmlns="http://xml.dataset.cassandraunit.org">
+	<name>reversedKeyspace</name>
+	<columnFamilies>
+		<columnFamily>
+			<name>columnFamilyWithReversedComparatorOnCompositeTypes</name>
+			<comparatorType>CompositeType(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))</comparatorType>
+			<row>
+				<key>row1</key>
+				<column>
+					<name>12:aa:11</name>
+					<value>v6</value>
+				</column>
+				<column>
+					<name>12:ab:12</name>
+					<value>v5</value>
+				</column>
+				<column>
+					<name>12:ab:11</name>
+					<value>v4</value>
+				</column>
+				<column>
+					<name>11:aa:11</name>
+					<value>v3</value>
+				</column>
+				<column>
+					<name>11:ab:12</name>
+					<value>v2</value>
+				</column>
+				<column>
+					<name>11:ab:11</name>
+					<value>v1</value>
+				</column>
+			</row>
+		</columnFamily>
+	</columnFamilies>
+</keyspace>

--- a/src/test/resources/xml/dataSetWithReversedComparatorOnSimpleType.xml
+++ b/src/test/resources/xml/dataSetWithReversedComparatorOnSimpleType.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<keyspace xmlns="http://xml.dataset.cassandraunit.org">
+	<name>reversedKeyspace</name>
+	<columnFamilies>
+		<columnFamily>
+			<name>columnFamilyWithReversedComparatorOnSimpleType</name>
+			<comparatorType>UTF8Type(reversed=true)</comparatorType>
+			<row>
+				<key>row1</key>
+				<column>
+					<name>c</name>
+					<value>c</value>
+				</column>
+				<column>
+					<name>b</name>
+					<value>b</value>
+				</column>
+				<column>
+					<name>a</name>
+					<value>a</value>
+				</column>
+			</row>
+		</columnFamily>
+	</columnFamilies>
+</keyspace>

--- a/src/test/resources/yaml/dataSetWithReversedComparatorOnCompositeTypes.yaml
+++ b/src/test/resources/yaml/dataSetWithReversedComparatorOnCompositeTypes.yaml
@@ -1,0 +1,13 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnCompositeTypes
+  comparatorType: CompositeType(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))
+  rows:
+  - key: row1
+    columns:
+    - {name: "12:aa:11", value: v6}
+    - {name: "12:ab:12", value: v5}
+    - {name: "12:ab:11", value: v4}
+    - {name: "11:aa:11", value: v3}
+    - {name: "11:ab:12", value: v2}
+    - {name: "11:ab:11", value: v1}

--- a/src/test/resources/yaml/dataSetWithReversedComparatorOnSimpleType.yaml
+++ b/src/test/resources/yaml/dataSetWithReversedComparatorOnSimpleType.yaml
@@ -1,0 +1,10 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnSimpleType
+  comparatorType: UTF8Type(reversed=true)
+  rows:
+  - key: row1
+    columns:
+    - {name: c, value: c}
+    - {name: b, value: b}
+    - {name: a, value: a}


### PR DESCRIPTION
Changelog:
- ComparatorTypes now accept 'reversed' qualifiers for both simple and
  composite types.
- Added unit tests to cover these new features.
- Added integration tests to cover these new features.

Signed-off-by: Marc CARRÉ carre.marc@gmail.com

URL: https://github.com/marccarre/cassandra-unit/commit/6aefd5cd3bfe53c79c6c1266b968269ed571deef
