### PR TITLE
disabling auto snapshoting functionality by default

### DIFF
--- a/src/main/resources/cu-cassandra.yaml
+++ b/src/main/resources/cu-cassandra.yaml
@@ -330,7 +330,7 @@ snapshot_before_compaction: false
 # or dropping of column families. The STRONGLY advised default of true 
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
-auto_snapshot: true
+auto_snapshot: false
 
 # Add column indexes to a row after its contents reach this size.
 # Increase if your column values are large, or if you have a very large


### PR DESCRIPTION
IMHO, snapshoting is not that useful for unit testing, as it just
increases test runtime.  Additionally, disabling auto snapshoting will
remove the dreaded "mklink: Path too long" error.

Feedback welcome. :)
