### PR TITLE
#27: ComparatorTypes now accepts 'reversed' qualifiers. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 /.settings
 /cassandra-unit.iml
 /.idea
+
+.DS_Store
+bin/
+cassandra-unit.ipr
+cassandra-unit.iws

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ https://github.com/jsevellec/cassandra-unit/wiki
 
 What is it?
 -----------
-Like over *Unit project, CassandraUnit is a Java utility test tool.
+Like other *Unit projects, CassandraUnit is a Java utility test tool.
 It helps you create your Java Application with Cassandra Database backend.
-CassandraUnit is for Cassandra what DBUnit is for Relational Database.
+CassandraUnit is for Cassandra what DBUnit is for Relational Databases.
 
-CassandraUnit helps you writing isolated Junit Test in a Test Driven Development style.
+CassandraUnit helps you writing isolated JUnit tests in a Test Driven Development style.
 
 Main features :
 ---------------
 - Start an embedded Cassandra.
-- Create structure (keyspace and Column family's) and load Data from an XML, JSON or YAML DataSet.
+- Create structure (keyspace and Column Families) and load data from an XML, JSON or YAML DataSet.
 
 Where to start :
 ----------------

--- a/src/main/java/org/cassandraunit/DataLoader.java
+++ b/src/main/java/org/cassandraunit/DataLoader.java
@@ -15,6 +15,7 @@ import me.prettyprint.hector.api.ddl.ComparatorType;
 import me.prettyprint.hector.api.ddl.KeyspaceDefinition;
 import me.prettyprint.hector.api.factory.HFactory;
 import me.prettyprint.hector.api.mutation.Mutator;
+import org.apache.commons.lang.StringUtils;
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.model.ColumnFamilyModel;
 import org.cassandraunit.model.ColumnMetadataModel;
@@ -36,11 +37,12 @@ import java.util.Map;
 
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre (#27)
  */
 public class DataLoader {
     Cluster cluster = null;
 
-    private Logger log = LoggerFactory.getLogger(DataLoader.class);
+    private static final Logger log = LoggerFactory.getLogger(DataLoader.class);
 
     public DataLoader(String clusterName, String host) {
         super();
@@ -243,7 +245,8 @@ public class DataLoader {
                 cfDef.setSubComparatorType(columnFamily.getSubComparatorType());
             }
 
-            if (ComparatorType.COMPOSITETYPE.equals(columnFamily.getComparatorType())) {
+            if (ComparatorType.COMPOSITETYPE.equals(columnFamily.getComparatorType())
+                    || StringUtils.containsIgnoreCase(columnFamily.getComparatorTypeAlias(), ColumnFamilyModel.REVERSED_QUALIFIER)) {
                 cfDef.setComparatorTypeAlias(columnFamily.getComparatorTypeAlias());
             }
 

--- a/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
+++ b/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre (#27)
  */
 public abstract class AbstractCommonsParserDataSet implements DataSet {
 
@@ -141,16 +142,21 @@ public abstract class AbstractCommonsParserDataSet implements DataSet {
 
         /* comparatorType */
         GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType = null;
-        if (parsedColumnFamily.getComparatorType() != null) {
-            ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(parsedColumnFamily
-                    .getComparatorType());
+        final String parsedComparatorType = parsedColumnFamily.getComparatorType();
+
+        if (parsedComparatorType != null) {
+
+            ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(parsedComparatorType);
             columnFamily.setComparatorType(comparatorType);
             if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
-                String comparatorTypeAlias = StringUtils.removeStart(parsedColumnFamily.getComparatorType(),
-                        ComparatorType.COMPOSITETYPE.getTypeName());
+                String comparatorTypeAlias = StringUtils.removeStart(parsedComparatorType, ComparatorType.COMPOSITETYPE.getTypeName());
                 columnFamily.setComparatorTypeAlias(comparatorTypeAlias);
                 typesBelongingCompositeTypeForComparatorType = ComparatorTypeHelper
                         .extractGenericTypesFromTypeAlias(comparatorTypeAlias);
+            } else if (StringUtils.containsIgnoreCase(parsedComparatorType, ColumnFamilyModel.REVERSED_QUALIFIER)) {
+                int begin = StringUtils.indexOfIgnoreCase(parsedComparatorType, ColumnFamilyModel.REVERSED_QUALIFIER);
+                int end = parsedComparatorType.length();
+                columnFamily.setComparatorTypeAlias(parsedComparatorType.substring(begin, end));
             }
         }
 

--- a/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
+++ b/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre (#27)
  */
 public abstract class AbstractXmlDataSet implements DataSet {
 
@@ -163,15 +164,23 @@ public abstract class AbstractXmlDataSet implements DataSet {
         }
 
         GenericTypeEnum[] typesBelongingCompositeTypeForComparatorType = null;
-        if (xmlColumnFamily.getComparatorType() != null) {
-            ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(xmlColumnFamily.getComparatorType());
+        final String xmlComparatorType = xmlColumnFamily.getComparatorType();
+
+        if (xmlComparatorType != null) {
+            ComparatorType comparatorType = ComparatorTypeHelper.verifyAndExtract(xmlComparatorType);
             columnFamily.setComparatorType(comparatorType);
             if (ComparatorType.COMPOSITETYPE.getTypeName().equals(comparatorType.getTypeName())) {
-                String comparatorTypeAlias = StringUtils.removeStart(xmlColumnFamily.getComparatorType(),
-                        ComparatorType.COMPOSITETYPE.getTypeName());
+                String comparatorTypeAlias = StringUtils.removeStart(xmlComparatorType, ComparatorType.COMPOSITETYPE.getTypeName());
                 columnFamily.setComparatorTypeAlias(comparatorTypeAlias);
                 typesBelongingCompositeTypeForComparatorType = ComparatorTypeHelper
                         .extractGenericTypesFromTypeAlias(comparatorTypeAlias);
+            } else if (StringUtils.containsIgnoreCase(xmlComparatorType,
+                    ColumnFamilyModel.REVERSED_QUALIFIER)) {
+                int begin = StringUtils.indexOfIgnoreCase(xmlComparatorType,
+                        ColumnFamilyModel.REVERSED_QUALIFIER);
+                int end = xmlComparatorType.length();
+                columnFamily.setComparatorTypeAlias(xmlComparatorType
+                        .substring(begin, end));
             }
         }
 

--- a/src/main/java/org/cassandraunit/model/ColumnFamilyModel.java
+++ b/src/main/java/org/cassandraunit/model/ColumnFamilyModel.java
@@ -8,8 +8,10 @@ import java.util.List;
 
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre (#27)
  */
 public class ColumnFamilyModel {
+    public static final String REVERSED_QUALIFIER = "(reversed=";
 
     private String name;
     private ColumnType type = ColumnType.STANDARD;

--- a/src/test/java/org/cassandraunit/DataLoaderTest.java
+++ b/src/test/java/org/cassandraunit/DataLoaderTest.java
@@ -57,9 +57,8 @@ import org.junit.Test;
 import com.google.common.base.Charsets;
 
 /**
- * 
  * @author Jeremy Sevellec
- * 
+ * @author Marc Carre (#27)
  */
 public class DataLoaderTest {
 
@@ -669,4 +668,89 @@ public class DataLoaderTest {
 				is("org.apache.cassandra.locator.SimpleStrategy"));
 	}
 
+    @Test
+    public void shouldLoadDataWithReversedComparatorOnSimpleType() {
+        String clusterName = "TestCluster6";
+        String host = "localhost:9171";
+        DataLoader dataLoader = new DataLoader(clusterName, host);
+
+        try {
+            dataLoader.load(MockDataSetHelper.getMockDataSetWithReversedComparatorOnSimpleType());
+
+			/* verify */
+            Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
+            Keyspace keyspace = HFactory.createKeyspace("reversedKeyspace", cluster);
+            RangeSlicesQuery<String, String, String> query = HFactory.createRangeSlicesQuery(keyspace, StringSerializer.get(), StringSerializer.get(),
+                    StringSerializer.get());
+            query.setColumnFamily("columnFamilyWithReversedComparatorOnSimpleType");
+            query.setRange(null, null, false, Integer.MAX_VALUE);
+            QueryResult<OrderedRows<String, String, String>> result = query.execute();
+            List<Row<String, String, String>> rows = result.get().getList();
+
+            assertThat(rows.size(), is(1));
+            assertThat(rows.get(0).getKey(), is("row1"));
+            assertThat(rows.get(0).getColumnSlice().getColumns().size(), is(3));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(0), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getName(), is("c"));
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getValue(), is("c"));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(1), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getName(), is("b"));
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getValue(), is("b"));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(2), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(2).getName(), is("a"));
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(2).getValue(), is("a"));
+        } catch (HInvalidRequestException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void shouldLoadDataWithReversedComparatorOnCompositeTypes() {
+        String clusterName = "TestCluster6";
+        String host = "localhost:9171";
+        DataLoader dataLoader = new DataLoader(clusterName, host);
+
+        try {
+            dataLoader.load(MockDataSetHelper.getMockDataSetWithReversedComparatorOnCompositeTypes());
+
+			/* verify */
+            Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
+            Keyspace keyspace = HFactory.createKeyspace("reversedKeyspace", cluster);
+            RangeSlicesQuery<String, Composite, String> query = HFactory.createRangeSlicesQuery(keyspace, StringSerializer.get(), CompositeSerializer.get(),
+                    StringSerializer.get());
+            query.setColumnFamily("columnFamilyWithReversedCompOnCompositeTypes");
+            query.setRange(null, null, false, Integer.MAX_VALUE);
+            QueryResult<OrderedRows<String, Composite, String>> result = query.execute();
+            List<Row<String, Composite, String>> rows = result.get().getList();
+
+            assertThat(rows.size(), is(1));
+            assertThat(rows.get(0).getKey(), is("row1"));
+            assertThat(rows.get(0).getColumnSlice().getColumns().size(), is(6));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(0), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(0).getValue(), is("v6"));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(1), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(1).getValue(), is("v5"));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(2), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(2).getValue(), is("v4"));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(3), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(3).getValue(), is("v3"));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(4), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(4).getValue(), is("v2"));
+
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(5), notNullValue());
+            assertThat(rows.get(0).getColumnSlice().getColumns().get(5).getValue(), is("v1"));
+        } catch (HInvalidRequestException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
 }

--- a/src/test/java/org/cassandraunit/dataset/json/ClasspathJsonDataSetTest.java
+++ b/src/test/java/org/cassandraunit/dataset/json/ClasspathJsonDataSetTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertThat;
 
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre (#27)
  */
 public class ClasspathJsonDataSetTest {
 
@@ -360,5 +361,73 @@ public class ClasspathJsonDataSetTest {
         DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithComparatorType.json");
         ColumnMetadataModel columnMetadata = dataSet.getColumnFamilies().get(0).getColumnsMetadata().get(0);
         assertThat(columnMetadata.getColumnName().getType(), is(GenericTypeEnum.TIME_UUID_TYPE));
+    }
+
+    @Test
+    public void shouldGetAColumnFamilyWithColumnsInReverseOrder() {
+        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithReversedComparatorOnSimpleType.json");
+
+        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+        assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnSimpleType"));
+        assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+        assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(reversed=true)"));
+
+        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+        ColumnModel column1 = columns.get(0);
+        assertThat(column1.getName().getValue(), is("c"));
+        assertThat(column1.getValue().getValue(), is("c"));
+
+        ColumnModel column2 = columns.get(1);
+        assertThat(column2.getName().getValue(), is("b"));
+        assertThat(column2.getValue().getValue(), is("b"));
+
+        ColumnModel column3 = columns.get(2);
+        assertThat(column3.getName().getValue(), is("a"));
+        assertThat(column3.getValue().getValue(), is("a"));
+    }
+
+    @Test
+    public void shouldGetAColumnFamilyWithCompositeColumnsInReverseOrder() {
+        DataSet dataSet = new ClassPathJsonDataSet("json/dataSetWithReversedComparatorOnCompositeTypes.json");
+
+        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+        assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnCompositeTypes"));
+        assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.COMPOSITETYPE.getTypeName()));
+        assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))"));
+
+        GenericTypeEnum[] expecTedTypesBelongingCompositeType = new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+                GenericTypeEnum.INTEGER_TYPE };
+        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+        assertThat(columns.get(0).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(0).getName().getCompositeValues(), is(new String[] { "12", "aa", "11" }));
+        assertThat(columns.get(0).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(0).getValue().getValue(), is("v6"));
+
+        assertThat(columns.get(1).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(1).getName().getCompositeValues(), is(new String[] { "12", "ab", "12" }));
+        assertThat(columns.get(1).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(1).getValue().getValue(), is("v5"));
+
+        assertThat(columns.get(2).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(2).getName().getCompositeValues(), is(new String[] { "12", "ab", "11" }));
+        assertThat(columns.get(2).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(2).getValue().getValue(), is("v4"));
+
+        assertThat(columns.get(3).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(3).getName().getCompositeValues(), is(new String[] { "11", "aa", "11" }));
+        assertThat(columns.get(3).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(3).getValue().getValue(), is("v3"));
+
+        assertThat(columns.get(4).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(4).getName().getCompositeValues(), is(new String[] { "11", "ab", "12" }));
+        assertThat(columns.get(4).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(4).getValue().getValue(), is("v2"));
+
+        assertThat(columns.get(5).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(5).getName().getCompositeValues(), is(new String[] { "11", "ab", "11" }));
+        assertThat(columns.get(5).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(5).getValue().getValue(), is("v1"));
     }
 }

--- a/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
+++ b/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 
 /**
  * @author Jeremy Sevellec
+ * @author Marc Carre (#27)
  */
 public class ClasspathXmlDataSetTest {
 
@@ -476,5 +477,71 @@ public class ClasspathXmlDataSetTest {
         assertThat(columnMetadata.getColumnName().getType(), is(GenericTypeEnum.TIME_UUID_TYPE));
     }
 
+    @Test
+    public void shouldGetAColumnFamilyWithColumnsInReverseOrder() {
+        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithReversedComparatorOnSimpleType.xml");
 
+        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+        assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnSimpleType"));
+        assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+        assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(reversed=true)"));
+
+        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+        ColumnModel column1 = columns.get(0);
+        assertThat(column1.getName().getValue(), is("c"));
+        assertThat(column1.getValue().getValue(), is("c"));
+
+        ColumnModel column2 = columns.get(1);
+        assertThat(column2.getName().getValue(), is("b"));
+        assertThat(column2.getValue().getValue(), is("b"));
+
+        ColumnModel column3 = columns.get(2);
+        assertThat(column3.getName().getValue(), is("a"));
+        assertThat(column3.getValue().getValue(), is("a"));
+    }
+
+    @Test
+    public void shouldGetAColumnFamilyWithCompositeColumnsInReverseOrder() {
+        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithReversedComparatorOnCompositeTypes.xml");
+
+        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+        assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnCompositeTypes"));
+        assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.COMPOSITETYPE.getTypeName()));
+        assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))"));
+
+        GenericTypeEnum[] expecTedTypesBelongingCompositeType = new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+                GenericTypeEnum.INTEGER_TYPE };
+        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+        assertThat(columns.get(0).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(0).getName().getCompositeValues(), is(new String[] { "12", "aa", "11" }));
+        assertThat(columns.get(0).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(0).getValue().getValue(), is("v6"));
+
+        assertThat(columns.get(1).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(1).getName().getCompositeValues(), is(new String[] { "12", "ab", "12" }));
+        assertThat(columns.get(1).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(1).getValue().getValue(), is("v5"));
+
+        assertThat(columns.get(2).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(2).getName().getCompositeValues(), is(new String[] { "12", "ab", "11" }));
+        assertThat(columns.get(2).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(2).getValue().getValue(), is("v4"));
+
+        assertThat(columns.get(3).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(3).getName().getCompositeValues(), is(new String[] { "11", "aa", "11" }));
+        assertThat(columns.get(3).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(3).getValue().getValue(), is("v3"));
+
+        assertThat(columns.get(4).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(4).getName().getCompositeValues(), is(new String[] { "11", "ab", "12" }));
+        assertThat(columns.get(4).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(4).getValue().getValue(), is("v2"));
+
+        assertThat(columns.get(5).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(5).getName().getCompositeValues(), is(new String[] { "11", "ab", "11" }));
+        assertThat(columns.get(5).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(5).getValue().getValue(), is("v1"));
+    }
 }

--- a/src/test/java/org/cassandraunit/dataset/yaml/ClasspathYamlDataSetTest.java
+++ b/src/test/java/org/cassandraunit/dataset/yaml/ClasspathYamlDataSetTest.java
@@ -17,9 +17,8 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 /**
- * 
  * @author Jeremy Sevellec
- * 
+ * @author Marc Carre (#27)
  */
 public class ClasspathYamlDataSetTest {
 
@@ -364,4 +363,71 @@ public class ClasspathYamlDataSetTest {
         assertThat(column3.getValue().getType(),is(GenericTypeEnum.UTF_8_TYPE));
     }
 
+    @Test
+    public void shouldGetAColumnFamilyWithColumnsInReverseOrder() {
+        DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithReversedComparatorOnSimpleType.yaml");
+
+        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+        assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnSimpleType"));
+        assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.UTF8TYPE.getTypeName()));
+        assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(reversed=true)"));
+
+        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+        ColumnModel column1 = columns.get(0);
+        assertThat(column1.getName().getValue(), is("c"));
+        assertThat(column1.getValue().getValue(), is("c"));
+
+        ColumnModel column2 = columns.get(1);
+        assertThat(column2.getName().getValue(), is("b"));
+        assertThat(column2.getValue().getValue(), is("b"));
+
+        ColumnModel column3 = columns.get(2);
+        assertThat(column3.getName().getValue(), is("a"));
+        assertThat(column3.getValue().getValue(), is("a"));
+    }
+
+    @Test
+    public void shouldGetAColumnFamilyWithCompositeColumnsInReverseOrder() {
+        DataSet dataSet = new ClassPathYamlDataSet("yaml/dataSetWithReversedComparatorOnCompositeTypes.yaml");
+
+        ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+        assertThat(columnFamilyModel.getName(), is("columnFamilyWithReversedComparatorOnCompositeTypes"));
+        assertThat(columnFamilyModel.getComparatorType().getTypeName(), is(ComparatorType.COMPOSITETYPE.getTypeName()));
+        assertThat(columnFamilyModel.getComparatorTypeAlias(), is("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))"));
+
+        GenericTypeEnum[] expecTedTypesBelongingCompositeType = new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
+                GenericTypeEnum.INTEGER_TYPE };
+        List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+
+        assertThat(columns.get(0).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(0).getName().getCompositeValues(), is(new String[] { "12", "aa", "11" }));
+        assertThat(columns.get(0).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(0).getValue().getValue(), is("v6"));
+
+        assertThat(columns.get(1).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(1).getName().getCompositeValues(), is(new String[] { "12", "ab", "12" }));
+        assertThat(columns.get(1).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(1).getValue().getValue(), is("v5"));
+
+        assertThat(columns.get(2).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(2).getName().getCompositeValues(), is(new String[] { "12", "ab", "11" }));
+        assertThat(columns.get(2).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(2).getValue().getValue(), is("v4"));
+
+        assertThat(columns.get(3).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(3).getName().getCompositeValues(), is(new String[] { "11", "aa", "11" }));
+        assertThat(columns.get(3).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(3).getValue().getValue(), is("v3"));
+
+        assertThat(columns.get(4).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(4).getName().getCompositeValues(), is(new String[] { "11", "ab", "12" }));
+        assertThat(columns.get(4).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(4).getValue().getValue(), is("v2"));
+
+        assertThat(columns.get(5).getName().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+        assertThat(columns.get(5).getName().getCompositeValues(), is(new String[] { "11", "ab", "11" }));
+        assertThat(columns.get(5).getName().getTypesBelongingCompositeType(), is(expecTedTypesBelongingCompositeType));
+        assertThat(columns.get(5).getValue().getValue(), is("v1"));
+    }
 }

--- a/src/test/java/org/cassandraunit/integration/ReversedComparatorWithCompositeTypesTest.java
+++ b/src/test/java/org/cassandraunit/integration/ReversedComparatorWithCompositeTypesTest.java
@@ -1,0 +1,148 @@
+package org.cassandraunit.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import me.prettyprint.cassandra.serializers.CompositeSerializer;
+import me.prettyprint.cassandra.serializers.IntegerSerializer;
+import me.prettyprint.cassandra.serializers.LongSerializer;
+import me.prettyprint.cassandra.serializers.StringSerializer;
+import me.prettyprint.cassandra.service.CassandraHostConfigurator;
+import me.prettyprint.hector.api.Cluster;
+import me.prettyprint.hector.api.Keyspace;
+import me.prettyprint.hector.api.beans.Composite;
+import me.prettyprint.hector.api.beans.HColumn;
+import me.prettyprint.hector.api.beans.OrderedRows;
+import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
+import me.prettyprint.hector.api.ddl.ComparatorType;
+import me.prettyprint.hector.api.factory.HFactory;
+import me.prettyprint.hector.api.mutation.Mutator;
+import me.prettyprint.hector.api.query.QueryResult;
+import me.prettyprint.hector.api.query.RangeSlicesQuery;
+
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.cassandraunit.DataLoader;
+import org.cassandraunit.dataset.yaml.ClassPathYamlDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReversedComparatorWithCompositeTypesTest {
+	private static final String KEYSPACE_NAME = "reversedKeyspace";
+	private static final String ROW_KEY = "row1";
+
+	private static final CompositeSerializer cs = CompositeSerializer.get();
+	private static final StringSerializer ss = StringSerializer.get();
+
+	@Before
+	public void before() throws Exception {
+		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+		DataLoader dataLoader = new DataLoader("TestCluster", "localhost:9171");
+		dataLoader.load(new ClassPathYamlDataSet("integration/emptyDataSetWithReversedComparatorOnCompositeTypes.yaml"));
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingCassandraUnit() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "columnFamilyWithReversedComparatorOnCompTypes";
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, Composite, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingHector() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "manuallyCreated";
+		createColumnFamily(cluster, columnFamily);
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, Composite, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	private void createColumnFamily(final Cluster cluster, final String columnFamily) {
+		final ColumnFamilyDefinition cfd = HFactory.createColumnFamilyDefinition(KEYSPACE_NAME, columnFamily, ComparatorType.COMPOSITETYPE);
+		cfd.setComparatorTypeAlias("(LongType(reversed=true),IntegerType,UTF8Type(reversed=true))");
+		cfd.setKeyValidationClass(UTF8Type.class.getName());
+		cfd.setDefaultValidationClass(UTF8Type.class.getName());
+		cluster.addColumnFamily(cfd, true);
+	}
+
+	private void writeDataSet(final Keyspace keyspace, final String columnFamily) {
+		final Mutator<String> mutator = HFactory.createMutator(keyspace, ss);
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 1, "a"), "v1", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 1, "b"), "v2", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 1, "c"), "v3", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 2, "a"), "v4", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 2, "b"), "v5", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(1, 2, "c"), "v6", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(2, 1, "a"), "v7", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(2, 1, "b"), "v8", cs, ss));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createColumn(getName(2, 1, "c"), "v9", cs, ss));
+		mutator.execute();
+	}
+
+	private Composite getName(final long i, final int j, final String string) {
+		final Composite composite = new Composite();
+		composite.addComponent(i, LongSerializer.get());
+		composite.addComponent(j, IntegerSerializer.get());
+		composite.addComponent(string, StringSerializer.get());
+		return composite;
+	}
+
+	private QueryResult<OrderedRows<String, Composite, String>> readDataSet(final Keyspace keyspace, final String columnFamily) {
+		final RangeSlicesQuery<String, Composite, String> query = HFactory.createRangeSlicesQuery(keyspace, ss, cs, ss);
+		query.setColumnFamily(columnFamily);
+		query.setRange(null, null, false, Integer.MAX_VALUE);
+		QueryResult<OrderedRows<String, Composite, String>> results = query.execute();
+		return results;
+	}
+
+	private void assertResultsAreSortedAccordingToComparator(QueryResult<OrderedRows<String, Composite, String>> results) {
+		assertNotNull(results);
+		assertNotNull(results.get());
+		assertNotNull(results.get().getList());
+		assertEquals(1, results.get().getList().size());
+		assertNotNull(results.get().getList().get(0));
+		assertEquals(ROW_KEY, results.get().getList().get(0).getKey());
+		assertNotNull(results.get().getList().get(0).getColumnSlice());
+
+		final List<HColumn<Composite, String>> columns = results.get().getList().get(0).getColumnSlice().getColumns();
+		assertNotNull(columns);
+
+		// assertEquals(getName(2, 1, "c"), columns.get(0).getName());
+		assertEquals("v9", columns.get(0).getValue());
+
+		// assertEquals(getName(2, 1, "b"), columns.get(1).getName());
+		assertEquals("v8", columns.get(1).getValue());
+
+		// assertEquals(getName(2, 1, "a"), columns.get(2).getName());
+		assertEquals("v7", columns.get(2).getValue());
+
+		// assertEquals(getName(1, 1, "c"), columns.get(3).getName());
+		assertEquals("v3", columns.get(3).getValue());
+
+		// assertEquals(getName(1, 1, "b"), columns.get(4).getName());
+		assertEquals("v2", columns.get(4).getValue());
+
+		// assertEquals(getName(1, 1, "a"), columns.get(5).getName());
+		assertEquals("v1", columns.get(5).getValue());
+
+		// assertEquals(getName(1, 2, "c"), columns.get(6).getName());
+		assertEquals("v6", columns.get(6).getValue());
+
+		// assertEquals(getName(1, 2, "b"), columns.get(7).getName());
+		assertEquals("v5", columns.get(7).getValue());
+
+		// assertEquals(getName(1, 2, "a"), columns.get(8).getName());
+		assertEquals("v4", columns.get(8).getValue());
+	}
+}

--- a/src/test/java/org/cassandraunit/integration/ReversedComparatorWithSimpleTypeTest.java
+++ b/src/test/java/org/cassandraunit/integration/ReversedComparatorWithSimpleTypeTest.java
@@ -1,0 +1,110 @@
+package org.cassandraunit.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import me.prettyprint.cassandra.serializers.StringSerializer;
+import me.prettyprint.cassandra.service.CassandraHostConfigurator;
+import me.prettyprint.hector.api.Cluster;
+import me.prettyprint.hector.api.Keyspace;
+import me.prettyprint.hector.api.beans.HColumn;
+import me.prettyprint.hector.api.beans.OrderedRows;
+import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
+import me.prettyprint.hector.api.ddl.ComparatorType;
+import me.prettyprint.hector.api.factory.HFactory;
+import me.prettyprint.hector.api.mutation.Mutator;
+import me.prettyprint.hector.api.query.QueryResult;
+import me.prettyprint.hector.api.query.RangeSlicesQuery;
+
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.cassandraunit.DataLoader;
+import org.cassandraunit.dataset.yaml.ClassPathYamlDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReversedComparatorWithSimpleTypeTest {
+	private static final String KEYSPACE_NAME = "reversedKeyspace";
+	private static final String ROW_KEY = "row1";
+
+	@Before
+	public void before() throws Exception {
+		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+		DataLoader dataLoader = new DataLoader("TestCluster", "localhost:9171");
+		dataLoader.load(new ClassPathYamlDataSet("integration/emptyDataSetWithReversedComparatorOnSimpleType.yaml"));
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingCassandraUnit() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "columnFamilyWithReversedComparatorOnSimpleType";
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, String, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	@Test
+	public void writeAndReadFromCfCreatedUsingHector() {
+		final Cluster cluster = HFactory.getOrCreateCluster("TestCluster", new CassandraHostConfigurator("localhost:9170"));
+		final Keyspace keyspace = HFactory.createKeyspace(KEYSPACE_NAME, cluster);
+
+		final String columnFamily = "manuallyCreated";
+		createColumnFamily(cluster, columnFamily);
+
+		writeDataSet(keyspace, columnFamily);
+		final QueryResult<OrderedRows<String, String, String>> results = readDataSet(keyspace, columnFamily);
+		assertResultsAreSortedAccordingToComparator(results);
+	}
+
+	private void createColumnFamily(final Cluster cluster, final String columnFamily) {
+		final ColumnFamilyDefinition cfd = HFactory.createColumnFamilyDefinition(KEYSPACE_NAME, columnFamily, ComparatorType.UTF8TYPE);
+		cfd.setComparatorTypeAlias("(reversed=true)");
+		cfd.setKeyValidationClass(UTF8Type.class.getName());
+		cfd.setDefaultValidationClass(UTF8Type.class.getName());
+		cluster.addColumnFamily(cfd, true);
+	}
+
+	private void writeDataSet(final Keyspace keyspace, final String columnFamily) {
+		final Mutator<String> mutator = HFactory.createMutator(keyspace, StringSerializer.get());
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createStringColumn("a", "v1"));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createStringColumn("b", "v2"));
+		mutator.addInsertion(ROW_KEY, columnFamily, HFactory.createStringColumn("c", "v3"));
+		mutator.execute();
+	}
+
+	private QueryResult<OrderedRows<String, String, String>> readDataSet(final Keyspace keyspace, final String columnFamily) {
+		final StringSerializer ss = StringSerializer.get();
+		final RangeSlicesQuery<String, String, String> query = HFactory.createRangeSlicesQuery(keyspace, ss, ss, ss);
+		query.setColumnFamily(columnFamily);
+		query.setRange(null, null, false, Integer.MAX_VALUE);
+		QueryResult<OrderedRows<String, String, String>> results = query.execute();
+		return results;
+	}
+
+	private void assertResultsAreSortedAccordingToComparator(QueryResult<OrderedRows<String, String, String>> results) {
+		assertNotNull(results);
+		assertNotNull(results.get());
+		assertNotNull(results.get().getList());
+		assertEquals(1, results.get().getList().size());
+		assertNotNull(results.get().getList().get(0));
+		assertEquals(ROW_KEY, results.get().getList().get(0).getKey());
+		assertNotNull(results.get().getList().get(0).getColumnSlice());
+
+		final List<HColumn<String, String>> columns = results.get().getList().get(0).getColumnSlice().getColumns();
+		assertNotNull(columns);
+
+		assertEquals("c", columns.get(0).getName());
+		assertEquals("v3", columns.get(0).getValue());
+
+		assertEquals("b", columns.get(1).getName());
+		assertEquals("v2", columns.get(1).getValue());
+
+		assertEquals("a", columns.get(2).getName());
+		assertEquals("v1", columns.get(2).getValue());
+	}
+}

--- a/src/test/java/org/cassandraunit/utils/ComparatorTypeHelperTest.java
+++ b/src/test/java/org/cassandraunit/utils/ComparatorTypeHelperTest.java
@@ -4,10 +4,15 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import me.prettyprint.hector.api.ddl.ComparatorType;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.type.GenericTypeEnum;
 import org.junit.Test;
 
+/**
+ * @author Jeremy Sevellec
+ * @author Marc Carre (#27)
+ */
 public class ComparatorTypeHelperTest {
 
 	@Test
@@ -60,4 +65,22 @@ public class ComparatorTypeHelperTest {
 		assertThat(genericTypesEnum, is(new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE,
 				GenericTypeEnum.INTEGER_TYPE }));
 	}
+
+    @Test
+    public void shouldExtractReversedType() {
+        ComparatorType typeWithReversedTrue = ComparatorTypeHelper.verifyAndExtract("UTF8Type(reversed=true)");
+        assertThat(typeWithReversedTrue, is(ComparatorType.UTF8TYPE));
+
+        ComparatorType typeWithReversedFalse = ComparatorTypeHelper.verifyAndExtract("UTF8Type(reversed=false)");
+        assertThat(typeWithReversedFalse, is(ComparatorType.UTF8TYPE));
+    }
+
+    @Test
+    public void shouldExtractReversedCompositeType() {
+        ComparatorType typesWithReversedTrue = ComparatorTypeHelper.verifyAndExtract("CompositeType(LongType(reversed=true),UTF8Type)");
+        assertThat(typesWithReversedTrue, is(ComparatorType.COMPOSITETYPE));
+
+        ComparatorType typesWithReversedFalse = ComparatorTypeHelper.verifyAndExtract("CompositeType(LongType(reversed=false),UTF8Type)");
+        assertThat(typesWithReversedFalse, is(ComparatorType.COMPOSITETYPE));
+    }
 }

--- a/src/test/java/org/cassandraunit/utils/MockDataSetHelper.java
+++ b/src/test/java/org/cassandraunit/utils/MockDataSetHelper.java
@@ -22,9 +22,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * 
  * @author Jeremy Sevellec
- * 
+ * @author Marc Carre (#27)
  */
 public class MockDataSetHelper {
 
@@ -712,4 +711,111 @@ public class MockDataSetHelper {
         return mockDataSet;
     }
 
+    public static DataSet getMockDataSetWithReversedComparatorOnSimpleType() {
+        DataSet mockDataSet = mock(DataSet.class);
+        KeyspaceModel keyspace = new KeyspaceModel();
+        keyspace.setName("reversedKeyspace");
+        keyspace.getColumnFamilies();
+
+		/* column family */
+        ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+        columnFamily.setName("columnFamilyWithReversedComparatorOnSimpleType");
+        columnFamily.setKeyType(ComparatorType.UTF8TYPE);
+        columnFamily.setComparatorType(ComparatorType.UTF8TYPE);
+        columnFamily.setComparatorTypeAlias("(reversed=true)");
+        columnFamily.setDefaultColumnValueType(ComparatorType.BYTESTYPE);
+
+		/* row1 */
+        RowModel row1 = new RowModel();
+        row1.setKey(new GenericType("row1", GenericTypeEnum.UTF_8_TYPE));
+
+		/* column1 */
+        ColumnModel column1 = new ColumnModel();
+        column1.setName(new GenericType("c", GenericTypeEnum.UTF_8_TYPE));
+        column1.setValue(new GenericType("c", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column1);
+
+		/* column2 */
+        ColumnModel column2 = new ColumnModel();
+        column2.setName(new GenericType("b", GenericTypeEnum.UTF_8_TYPE));
+        column2.setValue(new GenericType("b", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column2);
+
+		/* column3 */
+        ColumnModel column3 = new ColumnModel();
+        column3.setName(new GenericType("a", GenericTypeEnum.UTF_8_TYPE));
+        column3.setValue(new GenericType("a", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column3);
+
+        columnFamily.getRows().add(row1);
+        keyspace.getColumnFamilies().add(columnFamily);
+        when(mockDataSet.getKeyspace()).thenReturn(keyspace);
+        when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
+
+        return mockDataSet;
+    }
+
+    public static DataSet getMockDataSetWithReversedComparatorOnCompositeTypes() {
+        DataSet mockDataSet = mock(DataSet.class);
+        KeyspaceModel keyspace = new KeyspaceModel();
+        keyspace.setName("reversedKeyspace");
+        keyspace.getColumnFamilies();
+
+		/* column family */
+        ColumnFamilyModel columnFamily = new ColumnFamilyModel();
+        columnFamily.setName("columnFamilyWithReversedCompOnCompositeTypes");
+        columnFamily.setKeyType(ComparatorType.UTF8TYPE);
+        columnFamily.setComparatorType(ComparatorType.COMPOSITETYPE);
+        columnFamily.setComparatorTypeAlias("(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))");
+        columnFamily.setDefaultColumnValueType(ComparatorType.BYTESTYPE);
+
+		/* row1 */
+        RowModel row1 = new RowModel();
+        row1.setKey(new GenericType("row1", GenericTypeEnum.UTF_8_TYPE));
+
+        GenericTypeEnum[] columnNameTypes = {GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE, GenericTypeEnum.INTEGER_TYPE};
+
+		/* column1 */
+        ColumnModel column1 = new ColumnModel();
+        column1.setName(new GenericType(new String[] { "12", "aa", "11" }, columnNameTypes));
+        column1.setValue(new GenericType("v6", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column1);
+
+		/* column2 */
+        ColumnModel column2 = new ColumnModel();
+        column2.setName(new GenericType(new String[] { "12", "ab", "12" }, columnNameTypes));
+        column2.setValue(new GenericType("v5", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column2);
+
+		/* column3 */
+        ColumnModel column3 = new ColumnModel();
+        column3.setName(new GenericType(new String[] { "12", "ab", "11" }, columnNameTypes));
+        column3.setValue(new GenericType("v4", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column3);
+
+		/* column4 */
+        ColumnModel column4 = new ColumnModel();
+        column4.setName(new GenericType(new String[] { "11", "aa", "11" }, columnNameTypes));
+        column4.setValue(new GenericType("v3", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column4);
+
+		/* column5 */
+        ColumnModel column5 = new ColumnModel();
+        column5.setName(new GenericType(new String[] { "11", "ab", "12" }, columnNameTypes));
+        column5.setValue(new GenericType("v2", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column5);
+
+		/* column6 */
+        ColumnModel column6 = new ColumnModel();
+        column6.setName(new GenericType(new String[] { "11", "ab", "11" }, columnNameTypes));
+        column6.setValue(new GenericType("v1", GenericTypeEnum.UTF_8_TYPE));
+        row1.getColumns().add(column6);
+
+        columnFamily.getRows().add(row1);
+        keyspace.getColumnFamilies().add(columnFamily);
+        when(mockDataSet.getKeyspace()).thenReturn(keyspace);
+        when(mockDataSet.getColumnFamilies()).thenReturn(keyspace.getColumnFamilies());
+
+        return mockDataSet;
+    }
 }

--- a/src/test/resources/integration/emptyDataSetWithReversedComparatorOnCompositeTypes.yaml
+++ b/src/test/resources/integration/emptyDataSetWithReversedComparatorOnCompositeTypes.yaml
@@ -1,0 +1,4 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnCompTypes
+  comparatorType: CompositeType(LongType(reversed=true),IntegerType,UTF8Type(reversed=true))

--- a/src/test/resources/integration/emptyDataSetWithReversedComparatorOnSimpleType.yaml
+++ b/src/test/resources/integration/emptyDataSetWithReversedComparatorOnSimpleType.yaml
@@ -1,0 +1,4 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnSimpleType
+  comparatorType: UTF8Type(reversed=true)

--- a/src/test/resources/json/dataSetWithReversedComparatorOnCompositeTypes.json
+++ b/src/test/resources/json/dataSetWithReversedComparatorOnCompositeTypes.json
@@ -1,0 +1,34 @@
+{
+    "name" : "reversedKeyspace",
+	"columnFamilies" : [{
+        "name" : "columnFamilyWithReversedComparatorOnCompositeTypes",
+		"comparatorType" : "CompositeType(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))",
+        "rows" : [{
+            "key" : "row1",
+            "columns" : [{
+                "name" : "12:aa:11",
+                "value" : "v6"
+            },
+            {
+            	"name" : "12:ab:12",
+                "value" : "v5"
+            },
+             {
+            	"name" : "12:ab:11",
+                "value" : "v4"
+            },
+             {
+            	"name" : "11:aa:11",
+                "value" : "v3"
+            },
+             {
+            	"name" : "11:ab:12",
+                "value" : "v2"
+            },
+             {
+            	"name" : "11:ab:11",
+                "value" : "v1"
+            }]
+        }]
+    }]
+}

--- a/src/test/resources/json/dataSetWithReversedComparatorOnSimpleType.json
+++ b/src/test/resources/json/dataSetWithReversedComparatorOnSimpleType.json
@@ -1,0 +1,22 @@
+{
+    "name" : "reversedKeyspace",
+	"columnFamilies" : [{
+        "name" : "columnFamilyWithReversedComparatorOnSimpleType",
+		"comparatorType" : "UTF8Type(reversed=true)",
+        "rows" : [{
+            "key" : "row1",
+            "columns" : [{
+                "name" : "c",
+                "value" : "c"
+            },
+            {
+            	"name" : "b",
+                "value" : "b"
+            },
+             {
+            	"name" : "a",
+                "value" : "a"
+            }]
+        }]
+    }]
+}

--- a/src/test/resources/xml/dataSetWithReversedComparatorOnCompositeTypes.xml
+++ b/src/test/resources/xml/dataSetWithReversedComparatorOnCompositeTypes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<keyspace xmlns="http://xml.dataset.cassandraunit.org">
+	<name>reversedKeyspace</name>
+	<columnFamilies>
+		<columnFamily>
+			<name>columnFamilyWithReversedComparatorOnCompositeTypes</name>
+			<comparatorType>CompositeType(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))</comparatorType>
+			<row>
+				<key>row1</key>
+				<column>
+					<name>12:aa:11</name>
+					<value>v6</value>
+				</column>
+				<column>
+					<name>12:ab:12</name>
+					<value>v5</value>
+				</column>
+				<column>
+					<name>12:ab:11</name>
+					<value>v4</value>
+				</column>
+				<column>
+					<name>11:aa:11</name>
+					<value>v3</value>
+				</column>
+				<column>
+					<name>11:ab:12</name>
+					<value>v2</value>
+				</column>
+				<column>
+					<name>11:ab:11</name>
+					<value>v1</value>
+				</column>
+			</row>
+		</columnFamily>
+	</columnFamilies>
+</keyspace>

--- a/src/test/resources/xml/dataSetWithReversedComparatorOnSimpleType.xml
+++ b/src/test/resources/xml/dataSetWithReversedComparatorOnSimpleType.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<keyspace xmlns="http://xml.dataset.cassandraunit.org">
+	<name>reversedKeyspace</name>
+	<columnFamilies>
+		<columnFamily>
+			<name>columnFamilyWithReversedComparatorOnSimpleType</name>
+			<comparatorType>UTF8Type(reversed=true)</comparatorType>
+			<row>
+				<key>row1</key>
+				<column>
+					<name>c</name>
+					<value>c</value>
+				</column>
+				<column>
+					<name>b</name>
+					<value>b</value>
+				</column>
+				<column>
+					<name>a</name>
+					<value>a</value>
+				</column>
+			</row>
+		</columnFamily>
+	</columnFamilies>
+</keyspace>

--- a/src/test/resources/yaml/dataSetWithReversedComparatorOnCompositeTypes.yaml
+++ b/src/test/resources/yaml/dataSetWithReversedComparatorOnCompositeTypes.yaml
@@ -1,0 +1,13 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnCompositeTypes
+  comparatorType: CompositeType(LongType(reversed=true),UTF8Type,IntegerType(reversed=true))
+  rows:
+  - key: row1
+    columns:
+    - {name: "12:aa:11", value: v6}
+    - {name: "12:ab:12", value: v5}
+    - {name: "12:ab:11", value: v4}
+    - {name: "11:aa:11", value: v3}
+    - {name: "11:ab:12", value: v2}
+    - {name: "11:ab:11", value: v1}

--- a/src/test/resources/yaml/dataSetWithReversedComparatorOnSimpleType.yaml
+++ b/src/test/resources/yaml/dataSetWithReversedComparatorOnSimpleType.yaml
@@ -1,0 +1,10 @@
+name: reversedKeyspace
+columnFamilies:
+- name: columnFamilyWithReversedComparatorOnSimpleType
+  comparatorType: UTF8Type(reversed=true)
+  rows:
+  - key: row1
+    columns:
+    - {name: c, value: c}
+    - {name: b, value: b}
+    - {name: a, value: a}


### PR DESCRIPTION
- ComparatorTypes now accepts 'reversed' qualifiers for both simple and
  composite types.
- Added unit tests to cover these new features.
- Added integration tests to cover these new features.

See also: https://github.com/jsevellec/cassandra-unit/issues/27

Signed-off-by: Marc CARRÉ carre.marc@gmail.com
