### PR TITLE
Issue #29 : CompositeType for column values

### DIFF
--- a/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
+++ b/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
@@ -167,7 +167,7 @@ public abstract class AbstractCommonsParserDataSet implements DataSet {
         }
 
         if (parsedColumnFamily.getDefaultColumnValueType() != null) {
-            columnFamily.setDefaultColumnValueType(ComparatorType.getByClassName(parsedColumnFamily
+            columnFamily.setDefaultColumnValueType( ComparatorTypeHelper.verifyAndExtract(parsedColumnFamily
                     .getDefaultColumnValueType().name()));
         }
 

--- a/src/main/xsd/dataset.xsd
+++ b/src/main/xsd/dataset.xsd
@@ -33,8 +33,8 @@
 			<element name="type" type="tns:ColumnFamilyType" minOccurs="0" maxOccurs="1" />
 			<element name="keyType" type="string" minOccurs="0" maxOccurs="1" />
 			<element name="comparatorType" type="string" minOccurs="0" maxOccurs="1" />
-			<element name="subComparatorType" type="tns:DataType" minOccurs="0" maxOccurs="1" />
-			<element name="defaultColumnValueType" type="tns:DataType" minOccurs="0" maxOccurs="1" />
+			<element name="subComparatorType" type="string" minOccurs="0" maxOccurs="1" />
+			<element name="defaultColumnValueType" type="string" minOccurs="0" maxOccurs="1" />
             <element name="comment" type="string" minOccurs="0" maxOccurs="1" />
             <element name="compactionStrategy" type="string" minOccurs="0" maxOccurs="1" />
             <element name="compactionStrategyOptions" type="tns:CompactionStrategyOptions" minOccurs="0" maxOccurs="1" />
@@ -68,24 +68,6 @@
 		</restriction>
 	</simpleType>
 
-	<simpleType name="DataType">
-		<restriction base="string">
-			<enumeration value="AsciiType" />
-			<enumeration value="BooleanType" />
-			<enumeration value="BytesType" />
-			<enumeration value="CounterColumnType" />
-			<enumeration value="DateType" />
-			<enumeration value="DoubleType" />
-			<enumeration value="FloatType" />
-			<enumeration value="IntegerType" />
-			<enumeration value="LexicalUUIDType" />
-			<enumeration value="LongType" />
-			<enumeration value="TimeUUIDType" />
-			<enumeration value="UTF8Type" />
-			<enumeration value="UUIDType" />			
-		</restriction>
-	</simpleType>
-
 	<complexType name="Row">
 		<sequence>
 			<element name="key" type="string" minOccurs="1" maxOccurs="1" />
@@ -97,7 +79,7 @@
 	<complexType name="ColumnMetadata">
 		<sequence>
 			<element name="name" type="string" minOccurs="1" maxOccurs="1" />
-			<element name="validationClass" type="tns:DataType" minOccurs="1" maxOccurs="1" />
+			<element name="validationClass" type="string" minOccurs="1" maxOccurs="1" />
 			<element name="indexType" type="tns:IndexType" minOccurs="0" maxOccurs="1" />
             <element name="indexName" type="string" minOccurs="0" maxOccurs="1" />
 		</sequence>

--- a/src/test/java/org/cassandraunit/SampleDataSetChecker.java
+++ b/src/test/java/org/cassandraunit/SampleDataSetChecker.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.cassandraunit.type.GenericTypeEnum.*;
 
 import java.util.List;
 
@@ -142,5 +143,42 @@ public class SampleDataSetChecker {
 		assertThat(columnFamilyModel2.getRows().get(0).getKey().getCompositeValues(), is(new String[] { "11", "a" }));
 		assertThat(columnFamilyModel2.getRows().get(0).getKey().getTypesBelongingCompositeType(),
 				is(new GenericTypeEnum[] { GenericTypeEnum.LONG_TYPE, GenericTypeEnum.UTF_8_TYPE }));
+	}
+
+	public static void assertThatKeyspaceModelWithValueCompositeTypeIsOk(DataSet dataSet) {
+		ColumnFamilyModel columnFamilyModel = dataSet.getColumnFamilies().get(0);
+		assertThat(columnFamilyModel.getName(), is("columnFamilyWithCompositeValue"));
+		
+		List<ColumnModel> columns = columnFamilyModel.getRows().get(0).getColumns();
+		
+		assertThat(columns.get(0).getName().getValue(), is("column1"));
+		assertThat(columns.get(0).getValue().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(0).getValue().getCompositeValues(), is(new String[] { "11", "aa" , "11" }));
+		assertThat(columns.get(0).getValue().getTypesBelongingCompositeType(), is(new GenericTypeEnum[] { LONG_TYPE, UTF_8_TYPE, INTEGER_TYPE }));
+
+		assertThat(columns.get(1).getName().getValue(), is("column2"));
+		assertThat(columns.get(1).getValue().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(1).getValue().getCompositeValues(), is(new String[] { "ab", "11" , "11" }));
+		assertThat(columns.get(1).getValue().getTypesBelongingCompositeType(), is(new GenericTypeEnum[] { UTF_8_TYPE, INTEGER_TYPE, LONG_TYPE }));
+
+		assertThat(columns.get(2).getName().getValue(), is("column3"));
+		assertThat(columns.get(2).getValue().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(2).getValue().getCompositeValues(), is(new String[] { "11", "ab" , "12" }));
+		assertThat(columns.get(2).getValue().getTypesBelongingCompositeType(), is(new GenericTypeEnum[] { INTEGER_TYPE, UTF_8_TYPE, LONG_TYPE }));
+		
+		
+		// ColumnFamily 'columnFamilyWithCompositeValueTyped'
+		assertThat(dataSet.getColumnFamilies().get(1).getName(), is("columnFamilyWithDefaultCompositeValueType"));
+		columns = dataSet.getColumnFamilies().get(1).getRows().get(0).getColumns();
+		
+		assertThat(columns.get(0).getName().getValue(), is("column1"));
+		assertThat(columns.get(0).getValue().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(0).getValue().getCompositeValues(), is(new String[] { "20", "ba" , "5" }));
+		assertThat(columns.get(0).getValue().getTypesBelongingCompositeType(), is(new GenericTypeEnum[] { LONG_TYPE, UTF_8_TYPE, INTEGER_TYPE }));
+
+		assertThat(columns.get(1).getName().getValue(), is("column2"));
+		assertThat(columns.get(1).getValue().getType(), is(GenericTypeEnum.COMPOSITE_TYPE));
+		assertThat(columns.get(1).getValue().getCompositeValues(), is(new String[] { "bc", "21" , "22" }));
+		assertThat(columns.get(1).getValue().getTypesBelongingCompositeType(), is(new GenericTypeEnum[] { UTF_8_TYPE, INTEGER_TYPE, LONG_TYPE }));
 	}
 }

--- a/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
+++ b/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithCompositeTypeIsOk;
+import static org.cassandraunit.SampleDataSetChecker.assertThatKeyspaceModelWithValueCompositeTypeIsOk;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -427,6 +428,12 @@ public class ClasspathXmlDataSetTest {
     public void shouldNotGetAColumnFamilyWithCompositeType() throws Exception {
         DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithBadCompositeType.xml");
         dataSet.getKeyspace();
+    }
+
+    @Test
+    public void shouldGetAColumnFamilyWithValueCompositeType() throws Exception {
+        DataSet dataSet = new ClassPathXmlDataSet("xml/dataSetWithValueCompositeType.xml");
+        assertThatKeyspaceModelWithValueCompositeTypeIsOk(dataSet);
     }
 
     @Test

--- a/src/test/resources/xml/dataSetWithValueCompositeType.xml
+++ b/src/test/resources/xml/dataSetWithValueCompositeType.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<keyspace xmlns="http://xml.dataset.cassandraunit.org">
+	<name>compositeKeyspace</name>
+	<columnFamilies>
+		<columnFamily>
+			<name>columnFamilyWithCompositeValue</name>
+			<comparatorType>UTF8Type</comparatorType>
+			<row>
+				<key>row1</key>
+				<column>
+					<name>column1</name>
+					<value>composite(long(11):utf8(aa):integer(11))</value>
+				</column>
+				<column>
+					<name>column2</name>
+					<value>composite(utf8(ab):integer(11):long(11))</value>
+				</column>
+				<column>
+					<name>column3</name>
+					<value>composite(integer(11):utf8(ab):long(12))</value>
+				</column>
+			</row>
+		</columnFamily>
+		
+		<columnFamily>
+			<name>columnFamilyWithDefaultCompositeValueType</name>
+			<comparatorType>UTF8Type</comparatorType>
+			<defaultColumnValueType>CompositeType(LongType,UTF8Type,IntegerType)</defaultColumnValueType>
+			<row>
+				<key>row1</key>
+				<column>
+					<name>column1</name>
+					<value>20:ba:5</value>
+				</column>
+				<column>
+					<name>column2</name>
+					<value>composite(utf8(bc):integer(21):long(22))</value>
+				</column>
+			</row>
+		</columnFamily>
+	</columnFamilies>
+</keyspace>


### PR DESCRIPTION
Bonjour,

J'ai rajouté la possibilité d'utiliser des valeurs de type Composite dans les datasets XML avec ce format : composite(long(11):utf8(aa):integer(11))

Si un defaultColumnValueType est un Composite, on peut directement écrire les valeurs séparés par :
ie. <defaultColumnValueType>CompositeType(LongType,UTF8Type,IntegerType)</defaultColumnValueType> et valeur : 20:ba:5
