### PR TITLE
Remove duplicate netty dependency

### DIFF
--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -197,12 +197,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.netty</groupId>
-            <artifactId>netty</artifactId>
-            <version>3.2.9.Final</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.6.1</version>


### PR DESCRIPTION
Cassandra includes a later version of Netty (3.8.0) which has the same package structure (org.jboss.netty..), so I'm not sure you need to explicitly include an earlier version here.

I have had this cause problems where classpath-ordering was causing the wrong version of the netty jar to be used, leading me to explicitly exclude 3.2.9.Final from Cassandra-Unit. Thought a pull request might help.
