### PR TITLE
update to cassandra-driver 2.0.0 and cassandra 2.0.5

### DIFF
--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/DummyCassandraConnector.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/DummyCassandraConnector.java
@@ -1,5 +1,6 @@
 package org.cassandraunit.spring;
 
+import com.datastax.driver.core.CloseFuture;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 
@@ -38,8 +39,10 @@ public class DummyCassandraConnector {
 
     @PreDestroy
     public void preDestroy() {
-        session.shutdown();
-        cluster.shutdown();
+        CloseFuture closeFuture = session.closeAsync();
+        closeFuture.force();
+        closeFuture = cluster.closeAsync();
+        closeFuture.force();
     }
 
     public Session getSession() {

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -140,12 +140,16 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>2.0.0-rc1</version>
+            <version>2.0.0</version>
             <exclusions>
-            <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             <!--<exclusion>-->
             <!--<groupId>org.apache.cassandra</groupId>-->
             <!--<artifactId>cassandra-thrift</artifactId>-->
@@ -173,7 +177,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/cassandra-unit/src/main/java/org/cassandraunit/AbstractCassandraUnit4CQLTestCase.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/AbstractCassandraUnit4CQLTestCase.java
@@ -1,5 +1,6 @@
 package org.cassandraunit;
 
+import com.datastax.driver.core.CloseFuture;
 import com.datastax.driver.core.Session;
 import org.cassandraunit.dataset.CQLDataSet;
 import org.cassandraunit.dataset.DataSet;
@@ -45,7 +46,8 @@ public abstract class AbstractCassandraUnit4CQLTestCase {
     public void after(){
         if(session!=null){
             log.debug("session shutdown");
-            session.shutdown();
+            CloseFuture closeFuture = session.closeAsync();
+            closeFuture.force();
         }
     }
 


### PR DESCRIPTION
API has changed in cassandra-java-driver and {session|cluster}.shutdown() have been deprecated and replace by closeAsync() since version 2.0.0-rc3: 
[api] Renamed shutdown to closeAsync and ShutdownFuture to CloseFuture. Clustering and Session also now implement Closeable (JAVA-247).

Conflict with guava version: exclude has to be done

Warning: may break compatibility with older cassandra version (or driver in rc)
