### PR TITLE
Bugfix : CQL Loader handle lines with blanks after semicolon

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/AbstractCQLDataSet.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/AbstractCQLDataSet.java
@@ -58,7 +58,8 @@ public abstract class AbstractCQLDataSet implements CQLDataSet {
         List<String> statements = new ArrayList<String>();
         StringBuffer statementUnderConstruction = new StringBuffer();
         for (String line : lines) {
-            statementUnderConstruction.append(line.trim());
+            line = line.trim();
+            statementUnderConstruction.append(line);
             if (endOfStatementLine(line)) {
                 statements.add(statementUnderConstruction.toString());
                 statementUnderConstruction.setLength(0);

--- a/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithBlankLineEndings.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithBlankLineEndings.java
@@ -1,0 +1,28 @@
+package org.cassandraunit;
+
+import com.datastax.driver.core.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * 
+ * @author Laurent Liger
+ *
+ */
+public class CQLDataLoadTestWithBlankLineEndings {
+
+    @Rule
+    public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet("cql/statementsWithBlankEndings.cql", "mykeyspace"));
+
+
+    @Test
+	public void testCQLDataAreInPlace() throws Exception {
+        ResultSet result = cassandraCQLUnit.session.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+        String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string",val);
+	}
+}

--- a/cassandra-unit/src/test/resources/cql/statementsWithBlankEndings.cql
+++ b/cassandra-unit/src/test/resources/cql/statementsWithBlankEndings.cql
@@ -1,0 +1,9 @@
+create table testcqltable (id uuid, value varchar, primary key(id));      
+
+insert into testcqltable(
+    id,value
+    )
+    values(
+    1690e8da-5bf8-49e8-9583-4dff8a570737,
+    'Cql loaded string'
+    );     


### PR DESCRIPTION
Hello, @jsevellec, I've found a bug when dealing with CQL files containing blank spaces after semicolon.
Here is a fix and a unit-test for this bug.

Thanks for reviewing it !

Laurent.
