### PR TITLE
Upgraded cassandra to 2.0.6.

### DIFF
--- a/cassandra-unit-spring/pom.xml
+++ b/cassandra-unit-spring/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
+      <version>15.0</version>
     </dependency>
     <dependency>
       <groupId>org.cassandraunit</groupId>

--- a/cassandra-unit-spring/src/test/resources/log4j.xml
+++ b/cassandra-unit-spring/src/test/resources/log4j.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<appender name="outputConsole" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out" />
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d [%t] %-5p %c{3} - %m%n" />
+		</layout>
+	</appender>
+
+	<root> 
+		<priority value ="info" /> 
+		<appender-ref ref="outputConsole" /> 
+	</root>
+
+
+</log4j:configuration>
+

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- Main motivation is the bug CASSANDRA-6687
- Upgraded guava to match cassandra 2.0.6 version, to be considered if
  this dependency should not be removed from casssandra-unit's pom.xml
  as it is resolved either way via cassandra, or if the cassandra guava
  dependency should not be excluded
- 6687 url: https://issues.apache.org/jira/browse/CASSANDRA-6687
