### PR TITLE
Fail when Cassandra daemon timesout

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -116,7 +116,10 @@ public class EmbeddedCassandraServerHelper {
             }
         });
         try {
-            startupLatch.await(timeout, MILLISECONDS);
+            if (!startupLatch.await(timeout, MILLISECONDS)) {
+                log.error("Cassandra daemon did not start after " + MILLISECONDS + "ms. Consider increasing the timeout");
+                throw new AssertionError("Cassandra daemon did not start within timeout");
+            }
         } catch (InterruptedException e) {
             log.error("Interrupted waiting for Cassandra daemon to start:", e);
             throw new AssertionError(e);


### PR DESCRIPTION
The countdown latch returns a boolean value when it timesout.

http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CountDownLatch.html#await(long,%20java.util.concurrent.TimeUnit)

This should be handled.