### PR TITLE
Use same version number for cassandra dependencies

### DIFF
--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The difference in version numbers for cassandra-driver-core and cassandra-all means that different versions of antlr is pulled in. This causes errors when running with other libraries that also requires antlr (like elastic search).
