### PR TITLE
ColumnFamilies are unordered when returned.

### DIFF
--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.4</version>
             <exclusions>
             <exclusion>
             <groupId>org.codehaus.jackson</groupId>
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/AbstractCQLDataSet.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/AbstractCQLDataSet.java
@@ -55,32 +55,8 @@ public abstract class AbstractCQLDataSet implements CQLDataSet {
     }
 
     private List<String> linesToCQLStatements(List<String> lines) {
-        List<String> statements = new ArrayList<String>();
-        StringBuffer statementUnderConstruction = new StringBuffer();
-        for (String line : lines) {
-            line = line.trim();
-            statementUnderConstruction.append(line);
-            if (endOfStatementLine(line)) {
-                statements.add(statementUnderConstruction.toString());
-                statementUnderConstruction.setLength(0);
-            } else {
-                statementUnderConstruction.append(" ");
-            }
-        }
-        return statements;
-    }
-
-//    private boolean spaceNeededAfter(String line) {
-//        boolean spaceNeeded = true;
-//        String[] characterWithoutSpaceNeededAfter = {"<", ">", ":", "=", "|", "("};
-//        if (StringUtils.endsWithAny(line, characterWithoutSpaceNeededAfter)) {
-//            spaceNeeded = false;
-//        }
-//        return spaceNeeded;
-//    }
-
-    private boolean endOfStatementLine(String line) {
-        return line.endsWith(END_OF_STATEMENT_DELIMITER);
+    	SimpleCQLLexer lexer = new SimpleCQLLexer(lines);
+    	return lexer.getStatements();
     }
 
     public List<String> getLines() {

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/SimpleCQLLexer.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/SimpleCQLLexer.java
@@ -1,0 +1,133 @@
+package org.cassandraunit.dataset.cql;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Steve Nicolai
+ */
+
+/* see the full CQL grammar at:
+ * https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/cql3/Cql.g
+ * 
+ * This parser a series of lines, removes comments and breaks the lines into statements
+ * at semicolon boundaries.
+ */
+
+public class SimpleCQLLexer {
+	
+	String text;
+	
+    enum LexState {
+    	
+    	DEFAULT,
+    	INSINGLELINECOMMENT,
+    	INMULTILINECOMMENT,
+    	INQUOTESTRING,
+    	INSQUOTESTRING,
+    	
+    }
+    
+    LexState state;
+    int pos;
+
+	public SimpleCQLLexer(List<String> lines) {
+    	StringBuffer t = new StringBuffer();
+    	for (String l : lines) {
+    		t.append(l);
+    		t.append('\n');
+    	}
+    	
+    	text = t.toString();
+    	pos = 0;
+    	state = LexState.DEFAULT;
+	}
+	
+	char getChar() {
+		if (pos < text.length())
+			return text.charAt(pos++);
+		else
+			return 0;
+	}
+	
+	char peekAhead() {
+		if (pos < text.length())
+			return text.charAt(pos);  // don't advance
+		else
+			return 0;
+	}
+	
+	/* Skip the peekAhead character and not copy it to the output.
+	 */
+	void advance() {
+		pos++;
+	}
+	
+	List<String> getStatements() {
+        List<String> statements = new ArrayList<String>();
+        StringBuffer statementUnderConstruction = new StringBuffer();
+
+        char c;
+    	while ((c = getChar()) != 0) {    		
+    		switch (state) {
+    		case DEFAULT: 
+    			if (c == '/' && peekAhead() == '/') {
+    				state = LexState.INSINGLELINECOMMENT;
+    				advance();
+    			} else if (c == '-' && peekAhead() == '-') {
+    				state = LexState.INSINGLELINECOMMENT;
+    				advance();
+    			} else if (c == '/' && peekAhead() == '*') {
+    				state = LexState.INMULTILINECOMMENT;
+    				advance();
+    			} else {
+    				statementUnderConstruction.append(c);
+    				if (c == '\"') {
+        				state = LexState.INQUOTESTRING;
+    				} else if (c == '\'') {
+    					state = LexState.INSQUOTESTRING;
+    				} else if (c == ';') {
+                        statements.add(statementUnderConstruction.toString());
+                        statementUnderConstruction.setLength(0);
+        			}
+    			}
+    			break;
+    		
+    		case INSINGLELINECOMMENT:
+    			if (c == '\n') {
+    				state = LexState.DEFAULT;
+    			}
+    			break;
+    			
+    		case INMULTILINECOMMENT:
+    			if (c == '*' && peekAhead() == '/') {
+    				state = LexState.DEFAULT;
+    				advance();
+    			}
+    			break;
+    		
+    		case INQUOTESTRING:
+				statementUnderConstruction.append(c);
+    			if (c == '"' && peekAhead() != '"') {
+    				state = LexState.DEFAULT;
+    			}
+    			break;
+    		
+			case INSQUOTESTRING:
+				statementUnderConstruction.append(c);
+				if (c == '\'' && peekAhead() != '\'') {
+					state = LexState.DEFAULT;
+				}
+				break;
+			}
+
+    	}
+    	
+    	if (statementUnderConstruction.length() > 0) {
+            statements.add(statementUnderConstruction.toString());
+    	}
+    	    	
+    	return statements;
+	}
+	
+}

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/SimpleCQLLexer.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/SimpleCQLLexer.java
@@ -34,7 +34,7 @@ public class SimpleCQLLexer {
 	public SimpleCQLLexer(List<String> lines) {
     	StringBuffer t = new StringBuffer();
     	for (String l : lines) {
-    		t.append(l);
+    		t.append(l.trim());
     		t.append('\n');
     	}
     	
@@ -80,6 +80,8 @@ public class SimpleCQLLexer {
     			} else if (c == '/' && peekAhead() == '*') {
     				state = LexState.INMULTILINECOMMENT;
     				advance();
+    			} else if (c == '\n') {
+    				statementUnderConstruction.append(' ');
     			} else {
     				statementUnderConstruction.append(c);
     				if (c == '\"') {
@@ -87,7 +89,7 @@ public class SimpleCQLLexer {
     				} else if (c == '\'') {
     					state = LexState.INSQUOTESTRING;
     				} else if (c == ';') {
-                        statements.add(statementUnderConstruction.toString());
+                        statements.add(statementUnderConstruction.toString().trim());
                         statementUnderConstruction.setLength(0);
         			}
     			}
@@ -122,9 +124,9 @@ public class SimpleCQLLexer {
 			}
 
     	}
-    	
-    	if (statementUnderConstruction.length() > 0) {
-            statements.add(statementUnderConstruction.toString());
+    	String tmp = statementUnderConstruction.toString().trim();
+    	if (tmp.length() > 0) {
+            statements.add(tmp);
     	}
     	    	
     	return statements;

--- a/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderCompositeTypeTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderCompositeTypeTest.java
@@ -2,6 +2,9 @@ package org.cassandraunit;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
 import me.prettyprint.cassandra.serializers.CompositeSerializer;
 import me.prettyprint.cassandra.serializers.IntegerSerializer;
 import me.prettyprint.cassandra.serializers.LongSerializer;
@@ -10,6 +13,7 @@ import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.beans.ColumnSlice;
 import me.prettyprint.hector.api.beans.Composite;
+import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
 import me.prettyprint.hector.api.ddl.ComparatorType;
 import me.prettyprint.hector.api.factory.HFactory;
 import me.prettyprint.hector.api.query.QueryResult;
@@ -27,6 +31,14 @@ public class DataLoaderCompositeTypeTest {
 		EmbeddedCassandraServerHelper.startEmbeddedCassandra();
 	}
 
+	ColumnFamilyDefinition findNamed(List<ColumnFamilyDefinition> l, String name) {
+		for (ColumnFamilyDefinition i : l) {
+			if (i.getName().equals(name))
+				return i;
+		}
+		return null;
+	}	
+	
 	@Test
 	public void shouldCreateKeyspaceAndLoadDataWithColumnCompositeType() {
 		String clusterName = "TestClusterCompositeType01";
@@ -35,10 +47,11 @@ public class DataLoaderCompositeTypeTest {
 		dataLoader.load(MockDataSetHelper.getMockDataSetWithCompositeType());
 		/* test */
 		Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
-		assertThat(cluster.describeKeyspace("compositeKeyspace").getCfDefs().get(0).getName(),
+		ColumnFamilyDefinition cfdef = findNamed(cluster.describeKeyspace("compositeKeyspace").getCfDefs(), "columnFamilyWithCompositeType");
+		assertThat(cfdef.getName(),
 				is("columnFamilyWithCompositeType"));
 		assertThat(
-				cluster.describeKeyspace("compositeKeyspace").getCfDefs().get(0).getComparatorType().getTypeName(),
+				cfdef.getComparatorType().getTypeName(),
 				is(ComparatorType
 						.getByClassName(
 								"CompositeType(org.apache.cassandra.db.marshal.LongType,org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.IntegerType)")
@@ -101,10 +114,11 @@ public class DataLoaderCompositeTypeTest {
 		dataLoader.load(MockDataSetHelper.getMockDataSetWithCompositeType());
 		/* test */
 		Cluster cluster = HFactory.getOrCreateCluster(clusterName, host);
-		assertThat(cluster.describeKeyspace("compositeKeyspace").getCfDefs().get(1).getName(),
+		ColumnFamilyDefinition cfdef = findNamed(cluster.describeKeyspace("compositeKeyspace").getCfDefs(), "columnFamilyWithRowKeyCompositeType");
+		assertThat(cfdef.getName(),
 				is("columnFamilyWithRowKeyCompositeType"));
 		assertThat(
-				cluster.describeKeyspace("compositeKeyspace").getCfDefs().get(1).getKeyValidationClass(),
+				cfdef.getKeyValidationClass(),
 				is("org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.LongType,org.apache.cassandra.db.marshal.UTF8Type)"));
 
 		Keyspace keyspace = HFactory.createKeyspace("compositeKeyspace", cluster);

--- a/cassandra-unit/src/test/resources/cql/simple.cql
+++ b/cassandra-unit/src/test/resources/cql/simple.cql
@@ -1,7 +1,15 @@
-
+// a simple single line comment
+-- other comment
+/* multi line comment start
+ * "with quoted text"
+ * and a mismatched quote "
+ * 'and more quotes'
+ * and mismatched ' quote
+ */  // and another comment
+ 
 CREATE TABLE testCQLTable (id uuid, value varchar, PRIMARY KEY(id));
-INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570737,'Cql loaded string');
+INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570737,'Cql loaded string');  -- on the end of the line
 
-INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570738,'BLA2');
+INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570738,'BLA2'); // with " a single ' quote
 
 INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570739,'BLA1');


### PR DESCRIPTION
Find the correct column family in the list for each test.

The list is returned in an unordered fashion.  On my machine, they are returned in the incorrect order for this test.  I suspect the implementation iterates over a map, so the order is indeterminate.