### PR TITLE
Make startup timeout configurable using the junit rule

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/BaseCassandraUnit.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/BaseCassandraUnit.java
@@ -7,15 +7,25 @@ import org.junit.rules.ExternalResource;
  * @author Marcin Szymaniuk
  */
 public abstract class BaseCassandraUnit extends ExternalResource {
+    
     protected String configurationFileName;
+    protected long startupTimeout;
+
+    public BaseCassandraUnit() {
+        this(EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT);
+    }
+    
+    public BaseCassandraUnit(long startupTimeout) {
+        this.startupTimeout = startupTimeout;
+    }
 
     @Override
     protected void before() throws Exception {
         /* start an embedded Cassandra */
         if (configurationFileName != null) {
-            EmbeddedCassandraServerHelper.startEmbeddedCassandra(configurationFileName);
+            EmbeddedCassandraServerHelper.startEmbeddedCassandra(configurationFileName, startupTimeout);
         } else {
-            EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+            EmbeddedCassandraServerHelper.startEmbeddedCassandra(startupTimeout);
         }
 
         /* create structure and load data */

--- a/cassandra-unit/src/main/java/org/cassandraunit/CassandraCQLUnit.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/CassandraCQLUnit.java
@@ -36,6 +36,14 @@ public class CassandraCQLUnit extends BaseCassandraUnit {
         this.port = port;
     }
 
+    public CassandraCQLUnit(CQLDataSet dataSet, String configurationFileName, String hostIp, int port, long startUpTimeout) {
+        super(startUpTimeout);
+        this.dataSet = dataSet;
+        this.configurationFileName = configurationFileName;
+        this.hostIp = hostIp;
+        this.port = port;
+    }
+
     protected void load() {
         cluster = new Cluster.Builder().addContactPoints(hostIp).withPort(port).build();
         session = cluster.connect();


### PR DESCRIPTION
The jUnit rule now accepts a parameter to configure the startup timeout. 
The default value is used if the parameter is not given.

Note that the API is not changed with this change-set.

I'm using it to provide a longer timeout when I run tests on my integration server, which is really slow and so often fails at the startup!
