### PR TITLE
pom cleanup and new shaded subproject

### DIFF
--- a/cassandra-unit-shaded/LICENSE.txt
+++ b/cassandra-unit-shaded/LICENSE.txt
@@ -1,0 +1,4 @@
+The sourcecode of cassandra-unit-shaded consists solely of the pom. The pom itself is licensed as CC0 (Public Domain, http://creativecommons.org/publicdomain/zero/1.0/).
+
+Any shaded libraries contained in the binary jar retain their original open source license, most times the apache license 2.0.
+

--- a/cassandra-unit-shaded/pom.xml
+++ b/cassandra-unit-shaded/pom.xml
@@ -51,6 +51,7 @@
                             <createDependencyReducedPom>true</createDependencyReducedPom>
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <minimizeJar>false</minimizeJar>
+                            <dependencyReducedPomLocation>${basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
 
                             <artifactSet>
                                 <includes>
@@ -112,6 +113,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin> <!-- http://stackoverflow.com/questions/8880361/superfluous-warnings-when-using-maven-shade-plugin -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <forceCreation>true</forceCreation>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/cassandra-unit-shaded/pom.xml
+++ b/cassandra-unit-shaded/pom.xml
@@ -20,7 +20,7 @@
         cassandra-unit-shaded is a replacement for cassandra-unit only, not also
         for cassandra-unit-spring. If you want to use both -shaded and
         -spring, then exclude cassandra-unit out of the imported dependencies
-        of cassandra-unit.
+        of cassandra-unit-spring.
     </description>
 
     <properties>

--- a/cassandra-unit-shaded/pom.xml
+++ b/cassandra-unit-shaded/pom.xml
@@ -1,0 +1,118 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.cassandraunit</groupId>
+        <artifactId>cassandra-unit-parent</artifactId>
+        <version>2.1.3.2-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.cassandraunit</groupId>
+    <artifactId>cassandra-unit-shaded</artifactId>
+    <version>2.1.3.2-SNAPSHOT</version>
+    <name>cassandra-unit-shaded</name>
+    <packaging>jar</packaging>
+    <description>
+        cassandra-unit with some shaded dependencies to avoid known version clashes. 
+
+        Make sure to depend on cassandra-unit-shaded in test-scope only, else 
+        your generated artefact will contain a lot of unneeded dependencies.
+
+        cassandra-unit-shaded is a replacement for cassandra-unit only, not also
+        for cassandra-unit-spring. If you want to use both -shaded and
+        -spring, then exclude cassandra-unit out of the imported dependencies
+        of cassandra-unit.
+    </description>
+
+    <properties>
+        <shade.prefix>org.cassandraunit.shaded</shade.prefix>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>2.1.3.2-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <minimizeJar>false</minimizeJar>
+
+                            <artifactSet>
+                                <includes>
+                                    <!-- included only to suppress dependency, not relocated -->
+                                    <include>org.cassandraunit:cassandra-unit</include>
+
+                                    <!-- included due to relocated sub-dependencies, but itself not relocated because Class.forName -->
+                                    <include>org.apache.cassandra:cassandra-all</include>
+
+                                    <!-- included and relocated due to clash between hector and cassandra itself -->
+                                    <include>org.apache.cassandra:cassandra-thrift</include>
+
+                                    <!-- included and relocated due to potential clashes, especially guava -->
+                                    <include>com.google.guava:guava</include>
+                                    <include>org.antlr:*</include>
+                                    <include>org.codehaus.jackson:*</include>
+                                    <include>com.yammer.metrics:metrics-core</include>
+                                    <include>com.addthis.metrics:*</include>
+                                    <include>io.netty:*</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.cassandra.thrift</pattern>
+                                    <shadedPattern>${shade.prefix}.org.apache.cassandra.thrift</shadedPattern>
+                                </relocation>
+                                <relocation><!-- guava. With Trailing dot else com.googlecode would also match -->
+                                    <pattern>com.google.</pattern>
+                                    <shadedPattern>${shade.prefix}.com.google.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.antlr</pattern>
+                                    <shadedPattern>${shade.prefix}.org.antlr</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.jackson</pattern>
+                                    <shadedPattern>${shade.prefix}.org.codehaus.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.yammer.metrics</pattern>
+                                    <shadedPattern>${shade.prefix}.com.yammer.metrics</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.addthis.metrics</pattern>
+                                    <shadedPattern>${shade.prefix}.com.addthis.metrics</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>${shade.prefix}.io.netty</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>false</addHeader>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cassandra-unit-spring/pom.xml
+++ b/cassandra-unit-spring/pom.xml
@@ -5,10 +5,12 @@
 		<artifactId>cassandra-unit-parent</artifactId>
         <version>2.1.3.2-SNAPSHOT</version>
 	</parent>
+    <groupId>org.cassandraunit</groupId>
 	<artifactId>cassandra-unit-spring</artifactId>
 	<packaging>jar</packaging>
 	<name>cassandra-unit-spring</name>
 	<description>Spring Test framework to develop with Cassandra</description>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -68,28 +70,107 @@
 			</plugin>
 		</plugins>
 	</build>
+
 	<dependencies>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <version>4.0.2.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <version>4.0.2.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>org.cassandraunit</groupId>
-      <artifactId>cassandra-unit</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${cu.spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${cu.spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- hamcrest could be moved to the test-scope. But as the examples do not declare hamcrest-deps in their pom, 
+             better leave them in compile-scope --> 
+        <dependency> <!-- dont mix self-contained hamcrest-all and hamcrest-submodules -->
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${cu.hamcrest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${cu.hamcrest.version}</version>
+        </dependency>
+
+        <!-- optional clients. The app defines which one to use and in which version -->
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${cu.cassandra.driver.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.hectorclient</groupId>
+            <artifactId>hector-core</artifactId>
+            <version>${cu.hector.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion> <!-- using the version of cassandra-unit -->
+                    <groupId>org.apache.cassandra</groupId>
+                    <artifactId>cassandra-thrift</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- log -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${cu.slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${cu.slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${cu.slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+            <scope>test</scope>
+        </dependency>
+
 	</dependencies>
 </project>
 

--- a/cassandra-unit-spring/pom.xml
+++ b/cassandra-unit-spring/pom.xml
@@ -133,7 +133,7 @@
             <groupId>org.hectorclient</groupId>
             <artifactId>hector-core</artifactId>
             <version>${cu.hector.version}</version>
-            <scope>test</scope>
+            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
+++ b/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
@@ -10,6 +10,7 @@ import org.cassandraunit.dataset.ClassPathDataSet;
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -28,7 +29,7 @@ import com.google.common.base.Preconditions;
  * 
  * @author Gaëtan Le Brun
  */
-public abstract class AbstractCassandraUnitTestExecutionListener extends AbstractTestExecutionListener {
+public abstract class AbstractCassandraUnitTestExecutionListener extends AbstractTestExecutionListener implements Ordered {
   private static final org.slf4j.Logger LOGGER      = LoggerFactory.getLogger(CassandraUnitTestExecutionListener.class);
   private static       boolean          initialized = false;
 
@@ -111,4 +112,10 @@ public abstract class AbstractCassandraUnitTestExecutionListener extends Abstrac
     }
   }
 
+  @Override
+  public int getOrder() {
+    // since spring 4.1 the default-order is LOWEST_PRECEDENCE. But we want to start EmbeddedCassandra even before
+    // the springcontext such that beans can connect to the started cassandra
+    return 0;
+  }
 }

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanAndDirtiesContextTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanAndDirtiesContextTest.java
@@ -1,11 +1,15 @@
 package org.cassandraunit.spring;
 
-import com.datastax.driver.core.ResultSet;
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -13,14 +17,14 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
-import static org.junit.Assert.assertEquals;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+import com.datastax.driver.core.ResultSet;
 
 /**
  * @author Gaëtan Le Brun
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(value = {"classpath:/autowired-context.xml"})
+@ContextConfiguration(value = {"classpath:/autowired-context.xml"},
+    initializers = {CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanAndDirtiesContextTest.EnsureUniqueContext.class} )
 @TestExecutionListeners({CassandraUnitDependencyInjectionTestExecutionListener.class, DependencyInjectionTestExecutionListener.class, DirtiesContextTestExecutionListener.class})
 @CassandraDataSet(value = {"cql/dataset1.cql"})
 @EmbeddedCassandra
@@ -55,4 +59,10 @@ public class CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanAndDir
         assertEquals(2, DummyCassandraConnector.getInstancesCounter());
     }
 
+    public static class EnsureUniqueContext implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext ctx) {
+        }
+    }
 }

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanTest.java
@@ -1,11 +1,14 @@
 package org.cassandraunit.spring;
 
 import com.datastax.driver.core.ResultSet;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -17,7 +20,8 @@ import static org.junit.Assert.assertEquals;
  * @author Gaëtan Le Brun
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(value = { "classpath:/autowired-context.xml" })
+@ContextConfiguration(value = {"classpath:/autowired-context.xml"},
+  initializers = {CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanTest.EnsureUniqueContext.class} )
 @TestExecutionListeners({CassandraUnitDependencyInjectionTestExecutionListener.class, DependencyInjectionTestExecutionListener.class})
 @CassandraDataSet(value = { "cql/dataset1.cql" })
 @EmbeddedCassandra
@@ -51,4 +55,10 @@ public class CassandraStartAndLoadWithCQLDatasetAnnotationAndAutowiredBeanTest {
     assertEquals(1, DummyCassandraConnector.getInstancesCounter());
   }
 
+  public static class EnsureUniqueContext implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext ctx) {
+    }
+  }
 }

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -9,8 +9,8 @@
     <artifactId>cassandra-unit</artifactId>
     <packaging>jar</packaging>
     <name>cassandra-unit</name>
-
     <description>Test framework to develop with Cassandra</description>
+
     <build>
         <resources>
             <resource>
@@ -138,40 +138,10 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
-            <artifactId>cassandra-driver-core</artifactId>
-            <version>2.1.4</version>
-            <exclusions>
-            <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            </exclusion>
-            <exclusion>
-            <!--<groupId>org.apache.cassandra</groupId>-->
-            <!--<artifactId>cassandra-thrift</artifactId>-->
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.1</version>
-        </dependency>
-
+            <version>${cu.junit.version}</version>
+        </dependency> 
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
@@ -186,53 +156,23 @@
                     <artifactId>log4j</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-            <artifactId>concurrentlinkedhashmap-lru</artifactId>
-            <version>1.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
-        </dependency>
-
-        <!-- log -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.6.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.2.4-1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.11</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hectorclient</groupId>
-            <artifactId>hector-core</artifactId>
-            <version>1.1-4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
+        <dependency> <!-- for cassandra-all because maven fails to reliably resolve the conflict with cassandra-driver-core -->
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>16.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -244,11 +184,76 @@
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>
         </dependency>
+        <!-- hamcrest could be moved to the test-scope. But as the examples do not declare hamcrest-deps in their pom, 
+             better leave them in compile-scope --> 
+        <dependency> <!-- dont mix self-contained hamcrest-all and hamcrest-submodules -->
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${cu.hamcrest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${cu.hamcrest.version}</version>
+        </dependency>
 
+
+        <!-- optional clients. The app defines which one to use and in which version -->
+        <dependency>
+            <groupId>org.hectorclient</groupId>
+            <artifactId>hector-core</artifactId>
+            <version>${cu.hector.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${cu.cassandra.driver.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.8.5</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- log -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${cu.slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${cu.slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${cu.slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
             <scope>test</scope>
         </dependency>
 

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -130,8 +130,6 @@
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
                 </configuration>
             </plugin>
-
-
         </plugins>
     </build>
 
@@ -164,8 +162,20 @@
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion> <!-- ST4 and stringtemplate seem to contain the same classes... ST4 is newer -->
+                    <groupId>org.antlr</groupId>
+                    <artifactId>stringtemplate</artifactId>
+                </exclusion>
+                <exclusion> <!-- is this used at all? -->
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -179,11 +189,6 @@
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
         </dependency>
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
-        </dependency>
         <!-- hamcrest could be moved to the test-scope. But as the examples do not declare hamcrest-deps in their pom, 
              better leave them in compile-scope --> 
         <dependency> <!-- dont mix self-contained hamcrest-all and hamcrest-submodules -->
@@ -196,7 +201,6 @@
             <artifactId>hamcrest-library</artifactId>
             <version>${cu.hamcrest.version}</version>
         </dependency>
-
 
         <!-- optional clients. The app defines which one to use and in which version -->
         <dependency>
@@ -256,6 +260,5 @@
             <version>1.2.17</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -185,10 +185,11 @@
             <version>16.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
         </dependency>
+
         <!-- hamcrest could be moved to the test-scope. But as the examples do not declare hamcrest-deps in their pom, 
              better leave them in compile-scope --> 
         <dependency> <!-- dont mix self-contained hamcrest-all and hamcrest-submodules -->

--- a/cassandra-unit/src/main/java/org/cassandraunit/DataLoader.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/DataLoader.java
@@ -15,7 +15,7 @@ import me.prettyprint.hector.api.ddl.ComparatorType;
 import me.prettyprint.hector.api.ddl.KeyspaceDefinition;
 import me.prettyprint.hector.api.factory.HFactory;
 import me.prettyprint.hector.api.mutation.Mutator;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.model.ColumnFamilyModel;
 import org.cassandraunit.model.ColumnMetadataModel;

--- a/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineLoader.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineLoader.java
@@ -7,7 +7,7 @@ import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.CQLDataLoader;
 import org.cassandraunit.DataLoader;
 import org.cassandraunit.LoadingOption;

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/ClassPathDataSet.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/ClassPathDataSet.java
@@ -1,6 +1,6 @@
 package org.cassandraunit.dataset;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.json.ClassPathJsonDataSet;
 import org.cassandraunit.dataset.xml.ClassPathXmlDataSet;
 import org.cassandraunit.dataset.yaml.ClassPathYamlDataSet;

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/FileDataSet.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/FileDataSet.java
@@ -1,6 +1,6 @@
 package org.cassandraunit.dataset;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.json.FileJsonDataSet;
 import org.cassandraunit.dataset.xml.FileXmlDataSet;
 import org.cassandraunit.dataset.yaml.FileYamlDataSet;

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/commons/AbstractCommonsParserDataSet.java
@@ -3,7 +3,7 @@ package org.cassandraunit.dataset.commons;
 import me.prettyprint.hector.api.ddl.ColumnIndexType;
 import me.prettyprint.hector.api.ddl.ColumnType;
 import me.prettyprint.hector.api.ddl.ComparatorType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.model.*;

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/AbstractCQLDataSet.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/cql/AbstractCQLDataSet.java
@@ -1,6 +1,6 @@
 package org.cassandraunit.dataset.cql;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.CQLDataSet;
 import org.cassandraunit.dataset.ParseException;
 

--- a/cassandra-unit/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/dataset/xml/AbstractXmlDataSet.java
@@ -3,7 +3,7 @@ package org.cassandraunit.dataset.xml;
 import me.prettyprint.hector.api.ddl.ColumnIndexType;
 import me.prettyprint.hector.api.ddl.ColumnType;
 import me.prettyprint.hector.api.ddl.ComparatorType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.model.*;

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/ComparatorTypeHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/ComparatorTypeHelper.java
@@ -2,7 +2,7 @@ package org.cassandraunit.utils;
 
 import me.prettyprint.hector.api.ddl.ComparatorType;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.dataset.commons.ParsedDataType;
 import org.cassandraunit.type.GenericTypeEnum;

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -201,7 +201,9 @@ public class EmbeddedCassandraServerHelper {
              com.datastax.driver.core.Session session = cluster.connect()) {
             List<String> keyspaces = new ArrayList<String>();
             for (com.datastax.driver.core.KeyspaceMetadata keyspace : cluster.getMetadata().getKeyspaces()) {
-                keyspaces.add(keyspace.getName());
+                if (!keyspace.getName().startsWith("system_")) {
+                    keyspaces.add(keyspace.getName());
+                }
             }
             for (String keyspace : keyspaces) {
                 session.execute("DROP KEYSPACE " + keyspace);

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -197,7 +197,7 @@ public class EmbeddedCassandraServerHelper {
         String host = DatabaseDescriptor.getRpcAddress().getHostName();
         int port = DatabaseDescriptor.getNativeTransportPort();
         try (com.datastax.driver.core.Cluster cluster =
-             com.datastax.driver.core.Cluster.builder().addContactPoint(host + ":" + port).build();
+             com.datastax.driver.core.Cluster.builder().addContactPoint(host).withPort(port).build();
              com.datastax.driver.core.Session session = cluster.connect()) {
             List<String> keyspaces = new ArrayList<String>();
             for (com.datastax.driver.core.KeyspaceMetadata keyspace : cluster.getMetadata().getKeyspaces()) {

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -201,7 +201,7 @@ public class EmbeddedCassandraServerHelper {
              com.datastax.driver.core.Session session = cluster.connect()) {
             List<String> keyspaces = new ArrayList<String>();
             for (com.datastax.driver.core.KeyspaceMetadata keyspace : cluster.getMetadata().getKeyspaces()) {
-                if (!keyspace.getName().startsWith("system_")) {
+                if (!keyspace.getName().startsWith("system_") && !keyspace.getName().equals("system")) {
                     keyspaces.add(keyspace.getName());
                 }
             }

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -9,7 +9,7 @@ import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.service.CassandraDaemon;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -97,6 +97,7 @@ public class EmbeddedCassandraServerHelper {
 
         System.setProperty("cassandra.config", "file:" + file.getAbsolutePath());
         System.setProperty("cassandra-foreground", "true");
+        System.setProperty("cassandra.native.epoll.enabled", "false"); // JNA doesnt cope with relocated netty
 
         // If there is no log4j config set already, set the default config
         if (System.getProperty("log4j.configuration") == null) {

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -185,9 +185,7 @@ public class EmbeddedCassandraServerHelper {
         for (KeyspaceDefinition keyspaceDefinition : keyspaces) {
             String keyspaceName = keyspaceDefinition.getName();
 
-            if (!INTERNAL_CASSANDRA_KEYSPACE.equals(keyspaceName)
-                    && !INTERNAL_CASSANDRA_AUTH_KEYSPACE.equals(keyspaceName)
-                    && !INTERNAL_CASSANDRA_TRACES_KEYSPACE.equals(keyspaceName)) {
+            if (!isSystemKeyspaceName(keyspaceName)) {
                 cluster.dropKeyspace(keyspaceName);
             }
         }
@@ -201,7 +199,7 @@ public class EmbeddedCassandraServerHelper {
              com.datastax.driver.core.Session session = cluster.connect()) {
             List<String> keyspaces = new ArrayList<String>();
             for (com.datastax.driver.core.KeyspaceMetadata keyspace : cluster.getMetadata().getKeyspaces()) {
-                if (!keyspace.getName().startsWith("system_") && !keyspace.getName().equals("system")) {
+                if (!isSystemKeyspaceName(keyspace.getName())) {
                     keyspaces.add(keyspace.getName());
                 }
             }
@@ -209,6 +207,12 @@ public class EmbeddedCassandraServerHelper {
                 session.execute("DROP KEYSPACE " + keyspace);
             }
         }
+    }
+    
+    private static boolean isSystemKeyspaceName(String keyspaceName) {
+        return    INTERNAL_CASSANDRA_KEYSPACE.equals(keyspaceName) 
+               || INTERNAL_CASSANDRA_AUTH_KEYSPACE.equals(keyspaceName)
+               || INTERNAL_CASSANDRA_TRACES_KEYSPACE.equals(keyspaceName);
     }
     
     private static void rmdir(String dir) throws IOException {

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/TypeExtractor.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/TypeExtractor.java
@@ -1,7 +1,7 @@
 package org.cassandraunit.utils;
 
 import me.prettyprint.hector.api.ddl.ComparatorType;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.type.GenericType;
 import org.cassandraunit.type.GenericTypeEnum;

--- a/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderTest.java
@@ -49,7 +49,6 @@ import me.prettyprint.hector.api.query.SuperSliceCounterQuery;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.http.annotation.Immutable;
 import org.cassandraunit.model.StrategyModel;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.cassandraunit.utils.MockDataSetHelper;

--- a/cassandra-unit/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/dataset/xml/ClasspathXmlDataSetTest.java
@@ -3,7 +3,6 @@ package org.cassandraunit.dataset.xml;
 import me.prettyprint.hector.api.ddl.ColumnIndexType;
 import me.prettyprint.hector.api.ddl.ColumnType;
 import me.prettyprint.hector.api.ddl.ComparatorType;
-import org.apache.commons.lang.StringUtils;
 import org.cassandraunit.dataset.DataSet;
 import org.cassandraunit.dataset.ParseException;
 import org.cassandraunit.model.ColumnFamilyModel;

--- a/cassandra-unit/src/test/java/org/cassandraunit/utils/FileTmpHelper.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/utils/FileTmpHelper.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class FileTmpHelper {
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <cu.junit.version>4.11</cu.junit.version>
-        <cu.slf4j.version>1.6.1</cu.slf4j.version>
+        <cu.slf4j.version>1.7.5</cu.slf4j.version>
         <cu.hector.version>1.1-4</cu.hector.version>
         <cu.cassandra.driver.version>2.1.4</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>pom</packaging>
 	<name>cassandra-unit-parent</name>
 	<version>2.1.3.2-SNAPSHOT</version>
-	<description>Test framekork to develop with Cassandra</description>
+	<description>Test framework to develop with Cassandra</description>
 	<url>https://github.com/jsevellec/cassandra-unit</url>
 	<licenses>
 		<license>
@@ -31,6 +31,13 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <cu.junit.version>4.11</cu.junit.version>
+        <cu.slf4j.version>1.6.1</cu.slf4j.version>
+        <cu.hector.version>1.1-4</cu.hector.version>
+        <cu.cassandra.driver.version>2.1.4</cu.cassandra.driver.version>
+        <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
+        <cu.hamcrest.version>1.3</cu.hamcrest.version>
 	</properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 	</scm>
 	<modules>
 		<module>cassandra-unit</module>
+		<module>cassandra-unit-shaded</module>
 		<module>cassandra-unit-spring</module>
 	</modules>
 


### PR DESCRIPTION
  * general cleanup of the dependencies
  * hector and cassandra-driver are now optional dependencies. The application should decide which client and version to use, the testframework should have no influence here.
  * Excluded commons-logging out of the dependencies because after the cleanup commons-logging is only used in cassandra-unit-spring by spring. The application should itself decide on how to implement logging by either including commons-logging and a slf4j-implementation or jcl-over-slf4j. 
Seems to be also more in line with http://docs.spring.io/spring/docs/current/spring-framework-reference/html/overview.html#overview-logging, but you may revert this if you think otherwise. At least the examples would need to be adapted.
  * fix Spring-TestExecutionListener with spring4.1 such that EmbeddedCassandra can be started before the SpringBeans
  * cassandra got quite a lot of dependencies, which often cause conflicts. Added a new subproject cassandra-unit-shaded which bundles and relocates some dependencies which are known to be cause version clashes (guava, netty, ...).
Didnt want to change the existing main project as a silent majority seems to be fine with the current state, thus a new project. 
cassandra-unit-shaded contains just cassandra-unit, not cassandra-unit-spring. But users can easily use -spring together with -shaded by excluding cassandra-unit out of the dependencies of -spring.
