### PR TITLE
Updated to use port 9042 instead of 9142.

### DIFF
--- a/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/EmbeddedCassandra.java
+++ b/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/EmbeddedCassandra.java
@@ -25,5 +25,5 @@ public @interface EmbeddedCassandra {
   String clusterName() default "Test Cluster";
   String host() default "127.0.0.1";
   // CQL port be default, use 9171 for Thrift
-  int port() default 9142;
+  int port() default 9042;
 }

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationTest.java
@@ -34,7 +34,7 @@ public class CassandraStartAndLoadWithCQLDatasetAnnotationTest {
   private void test() {
     Cluster cluster = Cluster.builder()
         .addContactPoints("127.0.0.1")
-        .withPort(9142)
+        .withPort(9042)
         .build();
     Session session = cluster.connect("cassandra_unit_keyspace");
     ResultSet result = session.execute("select * from testCQLTable1 WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570717");

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetRootLocationAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetRootLocationAnnotationTest.java
@@ -34,7 +34,7 @@ public class CassandraStartAndLoadWithCQLDatasetRootLocationAnnotationTest {
   private void test() {
     Cluster cluster = Cluster.builder()
         .addContactPoints("127.0.0.1")
-        .withPort(9142)
+        .withPort(9042)
         .build();
     Session session = cluster.connect("cassandra_unit_keyspace");
     ResultSet result = session.execute("select * from testCQLTableRootLocation WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570797");

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLsDatasetAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLsDatasetAnnotationTest.java
@@ -34,7 +34,7 @@ public class CassandraStartAndLoadWithCQLsDatasetAnnotationTest {
   private void test() {
     Cluster cluster = Cluster.builder()
         .addContactPoints("127.0.0.1")
-        .withPort(9142)
+        .withPort(9042)
         .build();
     Session session = cluster.connect("cassandra_unit_keyspace");
 

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCassandraUnitAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCassandraUnitAnnotationTest.java
@@ -33,7 +33,7 @@ public class CassandraStartAndLoadWithCassandraUnitAnnotationTest {
   private void test() {
     Cluster cluster = Cluster.builder()
         .addContactPoints("127.0.0.1")
-            .withPort(9142)
+            .withPort(9042)
         .build();
     Session session = cluster.connect("cassandra_unit_keyspace");
     ResultSet result = session.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithGivenKeyspaceTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithGivenKeyspaceTest.java
@@ -34,7 +34,7 @@ public class CassandraStartAndLoadWithGivenKeyspaceTest {
   private void test() {
     Cluster cluster = Cluster.builder()
         .addContactPoints("127.0.0.1")
-        .withPort(9142)
+        .withPort(9042)
         .build();
     Session session = cluster.connect("myownkeyspace");
     ResultSet result = session.execute("select * from testCQLTableKS WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570787");

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringDependencyInjectionTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringDependencyInjectionTest.java
@@ -33,7 +33,7 @@ public class CassandraStartAndLoadWithSpringDependencyInjectionTest {
   public void should_work() {
     Cluster cluster = Cluster.builder()
             .addContactPoints("127.0.0.1")
-            .withPort(9142)
+            .withPort(9042)
             .build();
     Session session = cluster.connect("cassandra_unit_keyspace");
     ResultSet result = session.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringRunnerTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringRunnerTest.java
@@ -34,7 +34,7 @@ public class CassandraStartAndLoadWithSpringRunnerTest {
   private void test() {
     Cluster cluster = Cluster.builder()
         .addContactPoints("127.0.0.1")
-        .withPort(9142)
+        .withPort(9042)
         .build();
     Session session = cluster.connect("cassandra_unit_keyspace");
     ResultSet result = session.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/DummyCassandraConnector.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/DummyCassandraConnector.java
@@ -31,7 +31,7 @@ public class DummyCassandraConnector {
     public void init() {
         cluster = Cluster.builder()
                 .addContactPoints("127.0.0.1")
-                .withPort(9142)
+                .withPort(9042)
                 .build();
         session = cluster.connect("cassandra_unit_keyspace");
     }

--- a/cassandra-unit/src/main/java/org/cassandraunit/CassandraCQLUnit.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/CassandraCQLUnit.java
@@ -15,7 +15,7 @@ public class CassandraCQLUnit extends BaseCassandraUnit {
 
     private static final Logger log = LoggerFactory.getLogger(CassandraCQLUnit.class);
     private String hostIp = "127.0.0.1";
-    private int port = 9142;
+    private int port = 9042;
     public Session session;
     public Cluster cluster;
 

--- a/cassandra-unit/src/main/resources/cu-cassandra.yaml
+++ b/cassandra-unit/src/main/resources/cu-cassandra.yaml
@@ -266,7 +266,7 @@ listen_address: 127.0.0.1
 
 start_native_transport: true
 # port for the CQL native transport to listen for clients on
-native_transport_port: 9142
+native_transport_port: 9042
 
 # Whether to start the thrift rpc server.
 start_rpc: true

--- a/cassandra-unit/src/test/java/org/cassandraunit/cli/CassandraUnitCommandLineLoaderTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/cli/CassandraUnitCommandLineLoaderTest.java
@@ -190,7 +190,7 @@ public class CassandraUnitCommandLineLoaderTest {
         String targetFileDataSet = FileTmpHelper.copyClassPathDataSetToTmpDirectory(this.getClass(),
                 "/cql/simpleWithKeyspaceCreation.cql");
         String host = "localhost";
-        String port = "9142";
+        String port = "9042";
         String[] args = {"-f", targetFileDataSet, "-h", host, "-p", port};
         CassandraUnitCommandLineLoader.main(args);
 


### PR DESCRIPTION
Updated to use port 9042 instead of 9142.

9042 is the default port as mentioned in the Cassandra documentation:  https://wiki.apache.org/cassandra/FAQ#ports