### PR TITLE
Adding support for configuring Cassandra startup timeout in @EmbeddedCassandra

### DIFF
--- a/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
+++ b/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
@@ -38,7 +38,9 @@ public abstract class AbstractCassandraUnitTestExecutionListener extends Abstrac
             AnnotationUtils.findAnnotation(testContext.getTestClass(), EmbeddedCassandra.class),
             "CassandraUnitTestExecutionListener must be used with @EmbeddedCassandra on " + testContext.getTestClass());
     if (!initialized) {
-      EmbeddedCassandraServerHelper.startEmbeddedCassandra(Optional.fromNullable(embeddedCassandra.configuration()).get());
+      String yamlFile = Optional.fromNullable(embeddedCassandra.configuration()).get();
+      long timeout = embeddedCassandra.timeout();
+      EmbeddedCassandraServerHelper.startEmbeddedCassandra(yamlFile, timeout);
       initialized = true;
     }
 

--- a/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/EmbeddedCassandra.java
+++ b/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/EmbeddedCassandra.java
@@ -21,4 +21,5 @@ import java.lang.annotation.Target;
 public @interface EmbeddedCassandra {
   // cassandra configuration file
   String configuration() default EmbeddedCassandraServerHelper.DEFAULT_CASSANDRA_YML_FILE;
+  long timeout() default EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT;
 }


### PR DESCRIPTION
This allows `cassandra-unit-spring` users to use the custom startup timeout functionality added in https://github.com/jsevellec/cassandra-unit/pull/89. Default timeout of 10 seconds is not enough for slow CI machines.