### PR TITLE
Fixing race condition on Cassandra startup

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -305,8 +305,9 @@ public class EmbeddedCassandraServerHelper {
         mkdirs();
         cleanup();
         mkdirs();
-        CommitLog.instance.resetUnsafe(); // cleanup screws w/ CommitLog, this
-        // brings it back to safe state
+        CommitLog commitLog = CommitLog.instance;
+        commitLog.getContext(); // wait for commit log allocator instantiation to avoid hanging on a race condition
+        commitLog.resetUnsafe(); // cleanup screws w/ CommitLog, this brings it back to safe state
     }
 
     private static void cleanup() throws IOException {


### PR DESCRIPTION
Some unit tests on our CI server were intermittently failing because of CassandraUnit failing to start embedded Cassandra within the timeout, similar to #128. Increasing timeout from default 10 seconds to 30 did not help. Relevant part of the logs:

    18:12:22,576 [COMMIT-LOG-ALLOCATOR] DEBUG org.apache.cassandra.db.commitlog.CommitLogSegmentManager - No segments in reserve; creating a fresh one
    18:12:22,712 [COMMIT-LOG-ALLOCATOR] DEBUG org.apache.cassandra.db.commitlog.CommitLogSegment - Creating new commit log segment target/embeddedCassandra/commitlog/CommitLog-4-1436724742688.log
    18:12:22,781 [main] DEBUG org.apache.cassandra.db.commitlog.CommitLogSegmentManager - Closing and clearing existing commit log segments...
    18:12:23,467 [COMMIT-LOG-ALLOCATOR] DEBUG org.apache.cassandra.db.commitlog.CommitLogSegmentManager - Total active commitlog segment space used is 33554432
    18:12:23,468 [COMMIT-LOG-ALLOCATOR] DEBUG org.apache.cassandra.db.commitlog.CommitLogSegmentManager - Total active commitlog segment space used is 33554432
    18:12:24,414 [pool-2-thread-1] INFO  org.apache.cassandra.db.ColumnFamilyStore - Initializing system.sstable_activity
    18:12:30,229 [COMMIT-LOG-ALLOCATOR] DEBUG org.apache.cassandra.db.commitlog.CommitLogSegmentManager - Total active commitlog segment space used is 33554432
    18:12:33,474 [COMMIT-LOG-ALLOCATOR] DEBUG org.apache.cassandra.db.commitlog.CommitLogSegmentManager - Total active commitlog segment space used is 33554432
    18:12:53,475 [main] ERROR org.cassandraunit.utils.EmbeddedCassandraServerHelper - Cassandra daemon did not start after MILLISECONDSms. Consider increasing the timeout

Relevant part of the tread dump at the moment of the timeout:
- `pool-2-thread-1` thread:
```
sun.misc.Unsafe.park(Native Method)
java.util.concurrent.locks.LockSupport.park(LockSupport.java:304)
org.apache.cassandra.utils.concurrent.WaitQueue$AbstractSignal.awaitUninterruptibly(WaitQueue.java:283)
org.apache.cassandra.db.commitlog.CommitLogSegmentManager.advanceAllocatingFrom(CommitLogSegmentManager.java:271)
org.apache.cassandra.db.commitlog.CommitLogSegmentManager.allocatingFrom(CommitLogSegmentManager.java:203)
org.apache.cassandra.db.commitlog.CommitLog.getContext(CommitLog.java:166)
org.apache.cassandra.db.Memtable.<init>(Memtable.java:66)
org.apache.cassandra.db.DataTracker.init(DataTracker.java:372)
org.apache.cassandra.db.DataTracker.<init>(DataTracker.java:56)
org.apache.cassandra.db.ColumnFamilyStore.<init>(ColumnFamilyStore.java:317)
org.apache.cassandra.db.ColumnFamilyStore.createColumnFamilyStore(ColumnFamilyStore.java:479)
org.apache.cassandra.db.ColumnFamilyStore.createColumnFamilyStore(ColumnFamilyStore.java:450)
org.apache.cassandra.db.Keyspace.initCf(Keyspace.java:328)
org.apache.cassandra.db.Keyspace.<init>(Keyspace.java:279)
org.apache.cassandra.db.Keyspace.open(Keyspace.java:121)
org.apache.cassandra.db.Keyspace.open(Keyspace.java:98)
org.apache.cassandra.db.SystemKeyspace.checkHealth(SystemKeyspace.java:599)
org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:284)
org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:536)
org.cassandraunit.utils.EmbeddedCassandraServerHelper$1.run(EmbeddedCassandraServerHelper.java:114)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
java.lang.Thread.run(Thread.java:745)
```
- `COMMIT-LOG-ALLOCATOR` thread:
```
sun.misc.Unsafe.park(Native Method)
java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
org.apache.cassandra.db.commitlog.CommitLogSegmentManager$1.runMayThrow(CommitLogSegmentManager.java:144)
org.apache.cassandra.utils.WrappedRunnable.run(WrappedRunnable.java:28)
java.lang.Thread.run(Thread.java:745)
```

After some investigation, this seems to be caused by this line in `EmbeddedCassandraServerHelper`:
```java
CommitLog.instance.resetUnsafe();
```
Since this is the first reference to `CommitLog` class for the current JVM, this leads to the initialisation of the static field `instance`, and a call to constructors of `CommitLog` and `CommitLogSegmentManager`. The latter will start `COMMIT-LOG-ALLOCATOR` thread which would allocate first commit log segment. In parallel, the main thread will call `resetUnsafe()` which will clear `activeSegments` and `availableSegments` queues and set `allocatingFrom` pointer to null. A race condition between these threads might cause invalid state of non-empty `activeSegments` and null  `allocatingFrom`, leading to Cassandra daemon thread `pool-2-thread-1` hanging later as it needs a commit log segment to create first system table `system.sstable_activity`, but the allocator never provides the segment as it thinks one already exists.

The proposed fix is to call `CommitLog.instance.getContext()` to fully initialise allocator thread before calling `resetUnsafe()`.