### PR TITLE
Update to Cassandra 2.2, update other dependencies

### DIFF
--- a/cassandra-unit-shaded/pom.xml
+++ b/cassandra-unit-shaded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.cassandraunit</groupId>
         <artifactId>cassandra-unit-parent</artifactId>
-        <version>2.1.3.2-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.cassandraunit</groupId>

--- a/cassandra-unit-spring/pom.xml
+++ b/cassandra-unit-spring/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.cassandraunit</groupId>
 		<artifactId>cassandra-unit-parent</artifactId>
-        <version>2.1.3.2-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
 	</parent>
     <groupId>org.cassandraunit</groupId>
 	<artifactId>cassandra-unit-spring</artifactId>

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.cassandraunit</groupId>
         <artifactId>cassandra-unit-parent</artifactId>
-        <version>2.1.3.2-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <groupId>org.cassandraunit</groupId>
     <artifactId>cassandra-unit</artifactId>
@@ -143,11 +143,15 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.1.5</version>
+            <version>2.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -186,12 +186,12 @@
         <dependency> <!-- for cassandra-all because maven fails to reliably resolve the conflict with cassandra-driver-core -->
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0</version>
+            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
+            <version>3.4</version>
         </dependency>
 
         <!-- hamcrest could be moved to the test-scope. But as the examples do not declare hamcrest-deps in their pom, 
@@ -231,13 +231,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.1</version>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -305,7 +305,7 @@ public class EmbeddedCassandraServerHelper {
         mkdirs();
         cleanup();
         mkdirs();
-        CommitLog.instance.resetUnsafe(); // cleanup screws w/ CommitLog, this
+        CommitLog.instance.resetUnsafe(true); // cleanup screws w/ CommitLog, this
         // brings it back to safe state
     }
 

--- a/cassandra-unit/src/test/java/org/cassandraunit/CassandraStartAndLoadWithBytesKeyTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/CassandraStartAndLoadWithBytesKeyTest.java
@@ -28,7 +28,8 @@ public class CassandraStartAndLoadWithBytesKeyTest {
 	public void shouldGetBytesKey() {
 		CqlQuery<byte[], String, byte[]> query = new CqlQuery<byte[], String, byte[]>(cassandraUnit.keyspace,
 				BytesArraySerializer.get(), StringSerializer.get(), BytesArraySerializer.get());
-		query.setQuery("SELECT * FROM MyColumnFamily");
+		query.setCqlVersion("3");
+		query.setQuery("SELECT * FROM test");
 		QueryResult<CqlRows<byte[], String, byte[]>> result = query.execute();
 		List<Row<byte[], String, byte[]>> rows = result.get().getList();
 		Row row = rows.get(0);

--- a/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderAndCQLExecutionTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderAndCQLExecutionTest.java
@@ -16,7 +16,8 @@ public class DataLoaderAndCQLExecutionTest {
 	public void doQuery() {
 		final CqlQuery<String, String, String> query = new CqlQuery<String, String, String>(cassandraUnit.keyspace,
 				StringSerializer.get(), StringSerializer.get(), StringSerializer.get());
-		query.setQuery("UPDATE test SET 'method' = 'namedMethodValue' WHERE KEY='KEY'");
+		query.setCqlVersion("3");
+		query.setQuery("SELECT * FROM test WHERE KEY='KEY'");
 		query.execute();
 	}
 

--- a/cassandra-unit/src/test/resources/xml/dataSetWithBytesKey.xml
+++ b/cassandra-unit/src/test/resources/xml/dataSetWithBytesKey.xml
@@ -3,7 +3,7 @@
 	<name>beautifulKeyspaceName</name>
 	<columnFamilies>
 		<columnFamily>
-			<name>MyColumnFamily</name>
+			<name>test</name>
 			<type>STANDARD</type>
 			<keyType>BytesType</keyType>
 			<comparatorType>UTF8Type</comparatorType>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>cassandra-unit-parent</artifactId>
 	<packaging>pom</packaging>
 	<name>cassandra-unit-parent</name>
-	<version>2.1.3.2-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 	<description>Test framework to develop with Cassandra</description>
 	<url>https://github.com/jsevellec/cassandra-unit</url>
 	<licenses>
@@ -35,7 +35,7 @@
 
         <cu.junit.version>4.11</cu.junit.version>
         <cu.slf4j.version>1.7.5</cu.slf4j.version>
-        <cu.hector.version>1.1-4</cu.hector.version>
+        <cu.hector.version>2.0-0</cu.hector.version>
         <cu.cassandra.driver.version>2.1.5</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <cu.junit.version>4.11</cu.junit.version>
-        <cu.slf4j.version>1.7.5</cu.slf4j.version>
+        <cu.junit.version>4.12</cu.junit.version>
+        <cu.slf4j.version>1.7.12</cu.slf4j.version>
         <cu.hector.version>2.0-0</cu.hector.version>
-        <cu.cassandra.driver.version>2.1.5</cu.cassandra.driver.version>
+        <cu.cassandra.driver.version>2.1.7.1</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>
 	</properties>


### PR DESCRIPTION
Update to Cassandra 2.2: It requires update of the Hector and adjustment of two tests because Cassandra 2.2 doesn't support CQL2 anymore.

This PR contains also update of all dependencies to latest stable versions.