### PR TITLE
Upgrade to cassandra 2.1.8

### DIFF
--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.1.5</version>
+            <version>2.1.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Would it be possible to merge this and do a release? There is a bug with static columns in earlier versions.