### PR TITLE
Bumped version of driver, getting rid of NoSuchMethodError on Cluster$Builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,13 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <cu.junit.version>4.12</cu.junit.version>
-        <cu.slf4j.version>1.7.12</cu.slf4j.version>
-        <cu.hector.version>2.0-0</cu.hector.version>
+		<cu.junit.version>4.12</cu.junit.version>
+		<cu.slf4j.version>1.7.12</cu.slf4j.version>
+		<cu.hector.version>2.0-0</cu.hector.version>
 		<cu.cassandra.all.version>2.2.2</cu.cassandra.all.version>
-        <cu.cassandra.driver.version>2.1.8</cu.cassandra.driver.version>
-        <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
-        <cu.hamcrest.version>1.3</cu.hamcrest.version>
+		<cu.cassandra.driver.version>2.2.0-rc3</cu.cassandra.driver.version>
+		<cu.spring.version>4.0.2.RELEASE</cu.spring.version>
+		<cu.hamcrest.version>1.3</cu.hamcrest.version>
 	</properties>
 
 </project>


### PR DESCRIPTION
When running the tests with the 2.1.x driver, the following exception is thrown. Updating to 2.2.0-rcX fixes the issue.

java.lang.NoSuchMethodError: com.datastax.driver.core.Cluster$Builder.addContactPoints(Ljava/lang/String;)Lcom/datastax/driver/core/Cluster$Builder;
	at org.cassandraunit.CassandraCQLUnit.load(CassandraCQLUnit.java:42)
	at org.cassandraunit.BaseCassandraUnit.before(BaseCassandraUnit.java:32)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:46)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:78)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:212)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:140)