### PR TITLE
Added readTimeoutMillis to overloaded constructors of CassandraCQLUnit.

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/BaseCassandraUnit.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/BaseCassandraUnit.java
@@ -3,34 +3,46 @@ package org.cassandraunit;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.rules.ExternalResource;
 
+import com.datastax.driver.core.SocketOptions;
+
 /**
  * @author Marcin Szymaniuk
  */
 public abstract class BaseCassandraUnit extends ExternalResource {
-    
-    protected String configurationFileName;
-    protected long startupTimeout;
 
-    public BaseCassandraUnit() {
-        this(EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT);
-    }
-    
-    public BaseCassandraUnit(long startupTimeout) {
-        this.startupTimeout = startupTimeout;
-    }
+	protected String configurationFileName;
+	protected long startupTimeoutMillis;
+	protected int readTimeoutMillis = 12000;
 
-    @Override
-    protected void before() throws Exception {
-        /* start an embedded Cassandra */
-        if (configurationFileName != null) {
-            EmbeddedCassandraServerHelper.startEmbeddedCassandra(configurationFileName, startupTimeout);
-        } else {
-            EmbeddedCassandraServerHelper.startEmbeddedCassandra(startupTimeout);
-        }
+	public BaseCassandraUnit() {
+		this(EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT);
+	}
 
-        /* create structure and load data */
-        load();
-    }
+	public BaseCassandraUnit(long startupTimeoutMillis) {
+		this.startupTimeoutMillis = startupTimeoutMillis;
+	}
 
-    protected abstract void load();
+	@Override
+	protected void before() throws Exception {
+		/* start an embedded Cassandra */
+		if (configurationFileName != null) {
+			EmbeddedCassandraServerHelper.startEmbeddedCassandra(configurationFileName, startupTimeoutMillis);
+		} else {
+			EmbeddedCassandraServerHelper.startEmbeddedCassandra(startupTimeoutMillis);
+		}
+
+		/* create structure and load data */
+		load();
+	}
+
+	protected abstract void load();
+
+	/**
+	 * Gets a base SocketOptions with an overridden readTimeoutMillis.
+	 */
+	protected SocketOptions getSocketOptions() {
+		SocketOptions socketOptions = new SocketOptions();
+		socketOptions.setReadTimeoutMillis(this.readTimeoutMillis);
+		return socketOptions;
+	}
 }

--- a/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithFullOptions.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithFullOptions.java
@@ -1,0 +1,32 @@
+package org.cassandraunit;
+
+import static org.junit.Assert.assertEquals;
+
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.datastax.driver.core.ResultSet;
+
+@Ignore("May not start multiple cassandras with different configuration in one JVM")
+public class CQLDataLoadTestWithFullOptions {
+
+	private static final long STARTUP_TIMEOUT_VALUE = 20000L;
+	private static final int READ_TIMEOUT_VALUE = 17000;
+
+	@Rule
+	public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet("cql/simple.cql",
+			"mykeyspace"), EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, STARTUP_TIMEOUT_VALUE,
+			READ_TIMEOUT_VALUE);
+
+	@Test
+	public void testNativeDriverAccessToRandomPort() throws Exception {
+		ResultSet result = cassandraCQLUnit.session
+				.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+		String val = result.iterator().next().getString("value");
+		assertEquals("Cql loaded string", val);
+	}
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithReadTimeout.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithReadTimeout.java
@@ -1,0 +1,44 @@
+package org.cassandraunit;
+
+import static org.junit.Assert.assertEquals;
+
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.datastax.driver.core.ResultSet;
+
+/**
+ * 
+ * @author Jeremy Sevellec
+ *
+ */
+public class CQLDataLoadTestWithReadTimeout {
+
+	private static final int READ_TIMEOUT_VALUE = 15000;
+
+	@Rule
+	public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet("cql/simple.cql",
+			"mykeyspace"), READ_TIMEOUT_VALUE);
+
+	@Test
+	public void testCQLDataAreInPlace() throws Exception {
+		test();
+
+	}
+
+	@Test
+	public void sameTestToMakeSureMultipleTestsAreFine() throws Exception {
+		test();
+
+	}
+
+	private void test() {
+		ResultSet result = cassandraCQLUnit.session
+				.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+		String val = result.iterator().next().getString("value");
+		assertEquals("Cql loaded string", val);
+	}
+
+}


### PR DESCRIPTION
Added integration tests to support new parameter.
Renamed startUpTimeout to startUpTimeoutMillis to match names, and to better inform user of the time units expected for the parameter.
Added SocketOptions to the ClusterBuilder.