### PR TITLE
Changes cassandra dependency to 3.2.1 and driver to datastax driver 3.0.0

### DIFF
--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithYAML2DatasetAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithYAML2DatasetAnnotationTest.java
@@ -48,7 +48,7 @@ public class CassandraStartAndLoadWithYAML2DatasetAnnotationTest {
     Cluster cluster = HFactory.getOrCreateCluster("Test Cluster", "localhost:9171");
     List<KeyspaceDefinition> keyspaces = cluster.describeKeyspaces();
     assertThat(cluster.describeKeyspaces(), notNullValue());
-    assertThat(keyspaces.size(), is(4));
+    assertThat(keyspaces.size(), is(6));
     assertThat(cluster.describeKeyspace("mykeyspacename"), notNullValue());
     assertThat(cluster.describeKeyspace("mykeyspacename").getName(), is("mykeyspacename"));
 

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithYAML3DatasetAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithYAML3DatasetAnnotationTest.java
@@ -48,7 +48,7 @@ public class CassandraStartAndLoadWithYAML3DatasetAnnotationTest {
     Cluster cluster = HFactory.getOrCreateCluster("Test Cluster", "localhost:9171");
     List<KeyspaceDefinition> keyspaces = cluster.describeKeyspaces();
     assertThat(cluster.describeKeyspaces(), notNullValue());
-    assertThat(keyspaces.size(), is(4));
+    assertThat(keyspaces.size(), is(6));
     assertThat(cluster.describeKeyspace("mykeyspacename"), notNullValue());
     assertThat(cluster.describeKeyspace("mykeyspacename").getName(), is("mykeyspacename"));
 

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithYAMLDatasetAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithYAMLDatasetAnnotationTest.java
@@ -48,7 +48,7 @@ public class CassandraStartAndLoadWithYAMLDatasetAnnotationTest {
     Cluster cluster = HFactory.getOrCreateCluster("Test Cluster", "localhost:9171");
     List<KeyspaceDefinition> keyspaces = cluster.describeKeyspaces();
     assertThat(cluster.describeKeyspaces(), notNullValue());
-    assertThat(keyspaces.size(), is(4));
+    assertThat(keyspaces.size(), is(6));
     assertThat(cluster.describeKeyspace("mykeyspacename"), notNullValue());
     assertThat(cluster.describeKeyspace("mykeyspacename").getName(), is("mykeyspacename"));
 

--- a/cassandra-unit/src/main/java/org/cassandraunit/CQLDataLoader.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/CQLDataLoader.java
@@ -54,7 +54,7 @@ public class CQLDataLoader {
                 ";keyspaceName=" + keyspaceName);
 
         if (dataSet.isKeyspaceDeletion()) {
-            String selectQuery = "SELECT keyspace_name FROM system.schema_keyspaces where keyspace_name='" + keyspaceName + "'";
+            String selectQuery = "SELECT keyspace_name FROM system_schema.keyspaces where keyspace_name='" + keyspaceName + "'";
             ResultSet keyspaceQueryResult = session.execute(selectQuery);
             if (keyspaceQueryResult.iterator().hasNext()) {
                 String dropQuery = "DROP KEYSPACE " + keyspaceName;

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -43,6 +43,8 @@ public class EmbeddedCassandraServerHelper {
     public static final String DEFAULT_LOG4J_CONFIG_FILE = "/log4j-embedded-cassandra.properties";
     private static final String INTERNAL_CASSANDRA_KEYSPACE = "system";
     private static final String INTERNAL_CASSANDRA_AUTH_KEYSPACE = "system_auth";
+    private static final String INTERNAL_CASSANDRA_DISTRIBUTED_KEYSPACE = "system_distributed";
+    private static final String INTERNAL_CASSANDRA_SCHEMA_KEYSPACE = "system_schema";
     private static final String INTERNAL_CASSANDRA_TRACES_KEYSPACE = "system_traces";
 
     private static CassandraDaemon cassandraDaemon = null;
@@ -256,10 +258,11 @@ public class EmbeddedCassandraServerHelper {
     private static boolean isSystemKeyspaceName(String keyspaceName) {
         return    INTERNAL_CASSANDRA_KEYSPACE.equals(keyspaceName) 
                || INTERNAL_CASSANDRA_AUTH_KEYSPACE.equals(keyspaceName)
+               || INTERNAL_CASSANDRA_DISTRIBUTED_KEYSPACE.equals(keyspaceName)
+               || INTERNAL_CASSANDRA_SCHEMA_KEYSPACE.equals(keyspaceName)
                || INTERNAL_CASSANDRA_TRACES_KEYSPACE.equals(keyspaceName);
     }
     
-
     private static void rmdir(String dir) throws IOException {
         File dirFile = new File(dir);
         if (dirFile.exists()) {
@@ -332,7 +335,6 @@ public class EmbeddedCassandraServerHelper {
 
     public static void mkdirs() {
         DatabaseDescriptor.createAllDirectories();
-
     }
 
     private static void readAndAdaptYaml(File cassandraConfig) throws IOException {

--- a/cassandra-unit/src/main/resources/cu-cassandra.yaml
+++ b/cassandra-unit/src/main/resources/cu-cassandra.yaml
@@ -38,6 +38,8 @@ hinted_handoff_throttle_in_kb: 1024
 # cross-dc handoff tends to be slower
 max_hints_delivery_threads: 2
 
+hints_directory: target/embeddedCassandra/hints
+
 # The following setting populates the page cache on memtable flush and compaction
 # WARNING: Enable this setting only when the whole node's data fits in memory.
 # Defaults to: false
@@ -70,7 +72,7 @@ permissions_validity_in_ms: 2000
 
 
 # The partitioner is responsible for distributing rows (by key) across
-# nodes in the cluster.  Any IPartitioner may be used, including your
+# nodes in the cluster.  Any IPartitioner may be used, including your/m
 # own as long as it is on the classpath.  Out of the box, Cassandra
 # provides org.apache.cassandra.dht.{Murmur3Partitioner, RandomPartitioner
 # ByteOrderedPartitioner, OrderPreservingPartitioner (deprecated)}.

--- a/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/DataLoaderTest.java
@@ -176,8 +176,6 @@ public class DataLoaderTest {
         assertThat(beautifulColumnFamily.getCompactionStrategy(),is("org.apache.cassandra.db.compaction.LeveledCompactionStrategy"));
         assertThat(beautifulColumnFamily.getCompactionStrategyOptions().get("sstable_size_in_mb"),is("10"));
         assertThat(beautifulColumnFamily.getGcGraceSeconds(),is(9999));
-        assertThat(beautifulColumnFamily.getMaxCompactionThreshold(),is(31));
-        assertThat(beautifulColumnFamily.getMinCompactionThreshold(),is(3));
         assertThat(beautifulColumnFamily.getReadRepairChance(),is(0.1d));
         assertThat(beautifulColumnFamily.isReplicateOnWrite(),is(false));
 
@@ -189,8 +187,10 @@ public class DataLoaderTest {
 		assertThat(amazingColumnFamily.getColumnType(), is(ColumnType.STANDARD));
 		assertThat(amazingColumnFamily.getComparatorType().getClassName(),
 				is(ComparatorType.UTF8TYPE.getClassName()));
-
-
+		assertThat(amazingColumnFamily.getCompactionStrategy(),is("org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"));
+		assertThat(amazingColumnFamily.getMaxCompactionThreshold(),is(31));
+        assertThat(amazingColumnFamily.getMinCompactionThreshold(),is(3));
+        
         ColumnFamilyDefinition columnFamilyWithSecondaryIndex = columnFamilyDefinitionsMap.get("columnFamilyWithSecondaryIndex");
         assertThat(columnFamilyWithSecondaryIndex.getName(), is("columnFamilyWithSecondaryIndex"));
 		assertThat(columnFamilyWithSecondaryIndex.getColumnMetadata(), notNullValue());

--- a/cassandra-unit/src/test/java/org/cassandraunit/utils/MockDataSetHelper.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/utils/MockDataSetHelper.java
@@ -115,8 +115,6 @@ public class MockDataSetHelper {
         compactionStrategyOptions.add(new CompactionStrategyOptionModel("sstable_size_in_mb", "10"));
         beautifulColumnFamily.setCompactionStrategyOptions(compactionStrategyOptions);
         beautifulColumnFamily.setGcGraceSeconds(9999);
-        beautifulColumnFamily.setMaxCompactionThreshold(31);
-        beautifulColumnFamily.setMinCompactionThreshold(3);
         beautifulColumnFamily.setReadRepairChance(0.1d);
         beautifulColumnFamily.setReplicationOnWrite(Boolean.FALSE);
 
@@ -154,6 +152,9 @@ public class MockDataSetHelper {
 		columnFamily2.setKeyType(ComparatorType.UTF8TYPE);
 		columnFamily2.setComparatorType(ComparatorType.UTF8TYPE);
 		columnFamily2.setDefaultColumnValueType(ComparatorType.UTF8TYPE);
+		columnFamily2.setCompactionStrategy("SizeTieredCompactionStrategy");
+		columnFamily2.setMaxCompactionThreshold(31);
+		columnFamily2.setMinCompactionThreshold(3);
 
 		columnFamilies.add(columnFamily2);
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
         <cu.junit.version>4.12</cu.junit.version>
         <cu.slf4j.version>1.7.12</cu.slf4j.version>
         <cu.hector.version>2.0-0</cu.hector.version>
-        <cu.cassandra.all.version>2.2.2</cu.cassandra.all.version>
-        <cu.cassandra.driver.version>2.1.9</cu.cassandra.driver.version>
+        <cu.cassandra.all.version>3.2.1</cu.cassandra.all.version>
+        <cu.cassandra.driver.version>3.0.0</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>
     </properties>


### PR DESCRIPTION
** Should probably be merged into a new 3.2 branch **

Changes query to enumerate cassandra keyspaces from system.schema.keyspaces to system_schema.keyspaces in CQLDataLoader
Changes isSystemKeyspace function in EmbeddedCassandraServerHelper to include new system_distributed and system_schema keyspaces
Changes Spring Unit tests which were asserting that the number of keyspaces available = 4, this is now 6 because of new keyspaces.
Changes cassandra-unit/src/main/resources/cu-cassandra.yaml to include hints directory, which is now required.
Changes DataLoaderTest and MockDataSetHelper, which were supplying min/max compaction thresholds to the LeveledCompactionStrategy, this are only compatible with the SizeTieredCompactionStrategy and are now being set on a different ColumnFamily wthin the same test.