### PR TITLE
#110 Create a single jvm wide cluster and session object

### DIFF
--- a/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
+++ b/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
@@ -44,26 +44,19 @@ public abstract class AbstractCassandraUnitTestExecutionListener extends Abstrac
       initialized = true;
     }
 
-    String clusterName = EmbeddedCassandraServerHelper.getClusterName(); 
-    String host = EmbeddedCassandraServerHelper.getHost();
-    int rpcPort = EmbeddedCassandraServerHelper.getRpcPort();
-    int nativeTransportPort = EmbeddedCassandraServerHelper.getNativeTransportPort();
-
     CassandraDataSet cassandraDataSet = AnnotationUtils.findAnnotation(testContext.getTestClass(), CassandraDataSet.class);
     if (cassandraDataSet != null) {
       List<String> dataset = null;
       ListIterator<String> datasetIterator = null;
       String keyspace = cassandraDataSet.keyspace();
+
       // TODO : find a way to hide them and avoid switch, need some refactoring cassandra-unit
       switch (cassandraDataSet.type()) {
         case cql:
           dataset = dataSetLocations(testContext, cassandraDataSet);
           datasetIterator = dataset.listIterator();
 
-          Cluster cluster = new Cluster.Builder().addContactPoints(host).withPort(nativeTransportPort).build();
-          Session session = cluster.connect();
-          
-          CQLDataLoader cqlDataLoader = new CQLDataLoader(session);
+          CQLDataLoader cqlDataLoader = new CQLDataLoader(EmbeddedCassandraServerHelper.getSession());
           while (datasetIterator.hasNext()) {
             String next = datasetIterator.next();
             boolean dropAndCreateKeyspace = datasetIterator.previousIndex() == 0;
@@ -73,6 +66,11 @@ public abstract class AbstractCassandraUnitTestExecutionListener extends Abstrac
         default:
           dataset = dataSetLocations(testContext, cassandraDataSet);
           datasetIterator = dataset.listIterator();
+
+          String clusterName = EmbeddedCassandraServerHelper.getClusterName();
+          String host = EmbeddedCassandraServerHelper.getHost();
+          int rpcPort = EmbeddedCassandraServerHelper.getRpcPort();
+
           DataLoader dataLoader = new DataLoader(clusterName, host + ":" + rpcPort);
           while (datasetIterator.hasNext()) {
             String next = datasetIterator.next();

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetAnnotationTest.java
@@ -3,6 +3,7 @@ package org.cassandraunit.spring;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -32,11 +33,7 @@ public class CassandraStartAndLoadWithCQLDatasetAnnotationTest {
   }
 
   private void test() {
-    Cluster cluster = Cluster.builder()
-        .addContactPoints("127.0.0.1")
-        .withPort(9142)
-        .build();
-    Session session = cluster.connect("cassandra_unit_keyspace");
+    Session session = EmbeddedCassandraServerHelper.getSession();
     ResultSet result = session.execute("select * from testCQLTable1 WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570717");
     String val = result.iterator().next().getString("value");
     assertEquals("1- Cql loaded string", val);

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetRootLocationAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLDatasetRootLocationAnnotationTest.java
@@ -3,6 +3,7 @@ package org.cassandraunit.spring;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -32,11 +33,7 @@ public class CassandraStartAndLoadWithCQLDatasetRootLocationAnnotationTest {
   }
 
   private void test() {
-    Cluster cluster = Cluster.builder()
-        .addContactPoints("127.0.0.1")
-        .withPort(9142)
-        .build();
-    Session session = cluster.connect("cassandra_unit_keyspace");
+    Session session = EmbeddedCassandraServerHelper.getSession();
     ResultSet result = session.execute("select * from testCQLTableRootLocation WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570797");
     String val = result.iterator().next().getString("value");
     assertEquals("Root- Cql loaded string", val);

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLsDatasetAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCQLsDatasetAnnotationTest.java
@@ -3,6 +3,7 @@ package org.cassandraunit.spring;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -32,11 +33,7 @@ public class CassandraStartAndLoadWithCQLsDatasetAnnotationTest {
   }
 
   private void test() {
-    Cluster cluster = Cluster.builder()
-        .addContactPoints("127.0.0.1")
-        .withPort(9142)
-        .build();
-    Session session = cluster.connect("cassandra_unit_keyspace");
+    Session session = EmbeddedCassandraServerHelper.getSession();
 
     ResultSet result = session.execute("select * from testCQLTable1 WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570717");
     String val = result.iterator().next().getString("value");

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCassandraUnitAnnotationTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithCassandraUnitAnnotationTest.java
@@ -3,6 +3,7 @@ package org.cassandraunit.spring;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -31,11 +32,7 @@ public class CassandraStartAndLoadWithCassandraUnitAnnotationTest {
   }
 
   private void test() {
-    Cluster cluster = Cluster.builder()
-        .addContactPoints("127.0.0.1")
-            .withPort(9142)
-        .build();
-    Session session = cluster.connect("cassandra_unit_keyspace");
+    Session session = EmbeddedCassandraServerHelper.getSession();
     ResultSet result = session.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
     String val = result.iterator().next().getString("value");
     assertEquals("Cql loaded string", val);

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithGivenKeyspaceTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithGivenKeyspaceTest.java
@@ -3,6 +3,7 @@ package org.cassandraunit.spring;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -32,11 +33,7 @@ public class CassandraStartAndLoadWithGivenKeyspaceTest {
   }
 
   private void test() {
-    Cluster cluster = Cluster.builder()
-        .addContactPoints("127.0.0.1")
-        .withPort(9142)
-        .build();
-    Session session = cluster.connect("myownkeyspace");
+    Session session = EmbeddedCassandraServerHelper.getSession();
     ResultSet result = session.execute("select * from testCQLTableKS WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570787");
     String val = result.iterator().next().getString("value");
     assertEquals("KS- Cql loaded string", val);

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringDependencyInjectionTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringDependencyInjectionTest.java
@@ -4,6 +4,7 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,11 +32,7 @@ public class CassandraStartAndLoadWithSpringDependencyInjectionTest {
     
   @Test
   public void should_work() {
-    Cluster cluster = Cluster.builder()
-            .addContactPoints("127.0.0.1")
-            .withPort(9142)
-            .build();
-    Session session = cluster.connect("cassandra_unit_keyspace");
+    Session session = EmbeddedCassandraServerHelper.getSession();
     ResultSet result = session.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
     String val = result.iterator().next().getString("value");
     assertEquals("Cql loaded string", val);

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringRunnerTest.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/CassandraStartAndLoadWithSpringRunnerTest.java
@@ -3,6 +3,7 @@ package org.cassandraunit.spring;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -32,11 +33,7 @@ public class CassandraStartAndLoadWithSpringRunnerTest {
   }
 
   private void test() {
-    Cluster cluster = Cluster.builder()
-        .addContactPoints("127.0.0.1")
-        .withPort(9142)
-        .build();
-    Session session = cluster.connect("cassandra_unit_keyspace");
+    Session session = EmbeddedCassandraServerHelper.getSession();
     ResultSet result = session.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
     String val = result.iterator().next().getString("value");
     assertEquals("Cql loaded string", val);

--- a/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/DummyCassandraConnector.java
+++ b/cassandra-unit-spring/src/test/java/org/cassandraunit/spring/DummyCassandraConnector.java
@@ -5,6 +5,7 @@ import javax.annotation.PreDestroy;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 
 /**
  * @author Gaëtan Le Brun
@@ -27,22 +28,8 @@ public class DummyCassandraConnector {
         return instancesCounter;
     }
 
-    @PostConstruct
-    public void init() {
-        cluster = Cluster.builder()
-                .addContactPoints("127.0.0.1")
-                .withPort(9142)
-                .build();
-        session = cluster.connect("cassandra_unit_keyspace");
-    }
-
-    @PreDestroy
-    public void preDestroy() {
-        session.close();
-        cluster.close();
-    }
 
     public Session getSession() {
-        return session;
+        return EmbeddedCassandraServerHelper.getSession();
     }
 }

--- a/cassandra-unit/src/main/java/org/cassandraunit/CassandraCQLUnit.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/CassandraCQLUnit.java
@@ -57,11 +57,8 @@ public class CassandraCQLUnit extends BaseCassandraUnit {
 
 	@Override
 	protected void load() {
-		String hostIp = EmbeddedCassandraServerHelper.getHost();
-		int port = EmbeddedCassandraServerHelper.getNativeTransportPort();
-		cluster = new Cluster.Builder().addContactPoints(hostIp).withPort(port).withSocketOptions(getSocketOptions())
-				.build();
-		session = cluster.connect();
+		cluster = EmbeddedCassandraServerHelper.getCluster();
+		session = EmbeddedCassandraServerHelper.getSession();
 		CQLDataLoader dataLoader = new CQLDataLoader(session);
 		dataLoader.load(dataSet);
 		session = dataLoader.getSession();
@@ -70,10 +67,6 @@ public class CassandraCQLUnit extends BaseCassandraUnit {
 	@Override
 	protected void after() {
 		super.after();
-		try (Cluster c = cluster; Session s = session) {
-			session = null;
-			cluster = null;
-		}
 	}
 
 	// Getters for those who do not like to directly access fields


### PR DESCRIPTION
@jsevellec This PR should fix the issues described in #110 

We found that the issue stemmed from creating and closing multiple `Cluster` and `Session` objects during the course of the tests.  Creating and re-using a single JVM wide `Cluster` and `Session` for all of our tests fixed this problem and also sped up the tests as there is a non-negligible cost to creating a new `Cluster`.