### PR TITLE
Use full qualified table name for truncate

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -246,7 +246,7 @@ public class EmbeddedCassandraServerHelper {
         for (TableMetadata table : tables) {
             final String tableName = table.getName();
             if (!excludeTableList.contains(tableName)) {
-                session.execute("truncate table " + tableName);
+                session.execute("truncate table " + keyspace + "." + tableName);
             }
         }
     }


### PR DESCRIPTION
Without this change an exception is thrown if no USE keyspace was executed before:

```
com.datastax.driver.core.exceptions.InvalidQueryException: No keyspace has been specified. USE a keyspace, or explicitly specify keyspace.tablename
```