### PR TITLE
Fix for Issue 206 - keyspaceCreation without Deletion error

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/CQLDataLoader.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/CQLDataLoader.java
@@ -1,11 +1,9 @@
 package org.cassandraunit;
 
+import com.datastax.driver.core.Session;
 import org.cassandraunit.dataset.CQLDataSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Session;
 
 /**
  * @author Marcin Szymaniuk
@@ -60,7 +58,7 @@ public class CQLDataLoader {
         }
 
         if (dataSet.isKeyspaceCreation()) {
-            String createQuery = "CREATE KEYSPACE " + keyspaceName + " WITH replication={'class' : 'SimpleStrategy', 'replication_factor':1} AND durable_writes = false";
+            String createQuery = "CREATE KEYSPACE IF NOT EXISTS " + keyspaceName + " WITH replication={'class' : 'SimpleStrategy', 'replication_factor':1} AND durable_writes = false";
             log.debug("executing : " + createQuery);
             session.execute(createQuery);
             String useQuery = "USE " + keyspaceName;

--- a/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithNoKeyspaceDeletion.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/CQLDataLoadTestWithNoKeyspaceDeletion.java
@@ -1,0 +1,35 @@
+package org.cassandraunit;
+
+import com.datastax.driver.core.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CQLDataLoadTestWithNoKeyspaceDeletion {
+
+    @Rule
+    public CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(new ClassPathCQLDataSet("cql/simple.cql", true, false, "mykeyspace"));
+
+
+    @Test
+    public void testCQLDataAreInPlace() throws Exception {
+        test();
+
+    }
+
+    @Test
+    public void sameTestToMakeSureMultipleTestsAreFine() throws Exception {
+        test();
+
+    }
+
+    private void test() {
+        final ResultSet result = cassandraCQLUnit.session.execute("SELECT * FROM testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+        final String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string", val);
+    }
+
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/dataset/cql/ClasspathCQLDataSetTest.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/dataset/cql/ClasspathCQLDataSetTest.java
@@ -47,7 +47,7 @@ public class ClasspathCQLDataSetTest {
         assertThat(dataSet.getCQLStatements(), notNullValue());
         assertThat(dataSet.getCQLStatements().isEmpty(), is(false));
         assertThat(dataSet.getCQLStatements().size(),is(4));
-        assertThat(dataSet.getCQLStatements().get(0),is("CREATE TABLE testCQLTable (id uuid, value varchar, PRIMARY KEY(id));"));
+        assertThat(dataSet.getCQLStatements().get(0), is("CREATE TABLE testCQLTable IF NOT EXISTS (id uuid, value varchar, PRIMARY KEY(id));"));
         assertThat(dataSet.getCQLStatements().get(1),is("INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570737,'Cql loaded string');"));
         assertThat(dataSet.getCQLStatements().get(2),is("INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570738,'BLA2');"));
         assertThat(dataSet.getCQLStatements().get(3),is("INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570739,'BLA1');"));

--- a/cassandra-unit/src/test/resources/cql/simple.cql
+++ b/cassandra-unit/src/test/resources/cql/simple.cql
@@ -7,7 +7,7 @@
  * and mismatched ' quote
  */  // and another comment
  
-CREATE TABLE testCQLTable (id uuid, value varchar, PRIMARY KEY(id));
+CREATE TABLE testCQLTable IF NOT EXISTS (id uuid, value varchar, PRIMARY KEY(id));
 INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570737,'Cql loaded string');  -- on the end of the line
 
 INSERT INTO testCQLTable(id, value) values(1690e8da-5bf8-49e8-9583-4dff8a570738,'BLA2'); // with " a single ' quote


### PR DESCRIPTION
Related to #206 

Added test for keyspace creation with no deletion, test failed, updated CQLDataLoader.java such that it would work.

Also seemed cleanest to modify simple.cql to have IF NOT EXISTS clause in table create, or it failed for that reason as well.  If you disagree, I'm happy to swap to a teardown or whatever seems best.