### PR TITLE
just sharing

### DIFF
--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -73,14 +73,6 @@
                     <artifactId>log4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpcore</artifactId>
                 </exclusion>
@@ -115,7 +107,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.0.27.Final</version>
+            <version>4.0.39.Final</version>
         </dependency>
 
         <!-- hamcrest could be moved to the test-scope. But as the examples do not declare hamcrest-deps in their pom, 

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -119,6 +119,8 @@ public class EmbeddedCassandraServerHelper {
             System.setProperty("log4j.configuration", "file:" + tmpDir + DEFAULT_LOG4J_CONFIG_FILE);
         }
 
+        DatabaseDescriptor.daemonInitialization();
+
         cleanupAndLeaveDirs();
         final CountDownLatch startupLatch = new CountDownLatch(1);
         ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
 
         <cu.junit.version>4.12</cu.junit.version>
         <cu.slf4j.version>1.7.12</cu.slf4j.version>
-        <cu.cassandra.all.version>3.9</cu.cassandra.all.version>
-        <cu.cassandra.driver.version>3.1.3</cu.cassandra.driver.version>
+        <cu.cassandra.all.version>3.10</cu.cassandra.all.version>
+        <cu.cassandra.driver.version>3.1.4</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>
     </properties>


### PR DESCRIPTION
I tried porting cassandra-unit to cassandra 3.10 and this is the result. Unfortunately, changes are not backwards compatible, thus cassandra-unit couldn't be used with older cassandras any more.