### PR TITLE
prevent startup-timeout by setting cassandra.unsafesystem

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -112,6 +112,7 @@ public class EmbeddedCassandraServerHelper {
         System.setProperty("cassandra.config", "file:" + file.getAbsolutePath());
         System.setProperty("cassandra-foreground", "true");
         System.setProperty("cassandra.native.epoll.enabled", "false"); // JNA doesnt cope with relocated netty
+        System.setProperty("cassandra.unsafesystem", "true"); // disable fsync for a massive speedup on old platters
 
         // If there is no log4j config set already, set the default config
         if (System.getProperty("log4j.configuration") == null) {


### PR DESCRIPTION
Latest cassandra-unit was too slow to startup, causing errors "Cassandra daemon did not start within timeout". This MR massively speeds up the embedded cassandra by disabling fsync which seems suitable for a non-durable Test-DB. See https://issues.apache.org/jira/browse/CASSANDRA-5704 for a documentation of the effects.

#191 already proposed such a change, but was replaced by "durable_writes=false".  On my aging battlestation this isnt sufficient. Either "cassandra.unsafesystem=true" or an explicit higher timeout is needed to prevent errors.
