### PR TITLE
Update Guava and Cassandra driver version

### DIFF
--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -97,7 +97,7 @@
         <dependency> <!-- for cassandra-all because maven fails to reliably resolve the conflict with cassandra-driver-core -->
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>21.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <cu.junit.version>4.12</cu.junit.version>
         <cu.slf4j.version>1.7.12</cu.slf4j.version>
         <cu.cassandra.all.version>3.10</cu.cassandra.all.version>
-        <cu.cassandra.driver.version>3.1.4</cu.cassandra.driver.version>
+        <cu.cassandra.driver.version>3.2.0</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>
     </properties>


### PR DESCRIPTION
Closes #233 

Changes:
- Use cassandra driver version 3.2.0
- Use Guava version 21.0