### PR TITLE
Shade thrift

### DIFF
--- a/cassandra-unit-shaded/pom.xml
+++ b/cassandra-unit-shaded/pom.xml
@@ -46,6 +46,7 @@
                                     <include>com.yammer.metrics:metrics-core</include>
                                     <include>com.addthis.metrics:*</include>
                                     <include>io.netty:*</include>
+                                    <include>org.apache.thrift:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -76,6 +77,10 @@
                                 <relocation>
                                     <pattern>io.netty</pattern>
                                     <shadedPattern>${shade.prefix}.io.netty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.thrift</pattern>
+                                    <shadedPattern>${shade.prefix}.org.apache.thrift</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>


### PR DESCRIPTION
Motivation:

Thrift’s pom on maven central is foobar: it has a pom packaging instead
of a jar one. While maven seems to deal with such invalid pom, ivy2
doesn’t. This causes cassandra-unit to crash with ivy based tools such
as gradle and sbt.

FWIW, I’ve send a PR to Thrift to fix this but I don’t expect Cassandra
to upgrade as Thrift is being dropped in next major release.

Modification:

Shade Thrift into shaded jar.

Result:

At least the shaded jar works with sbt and gradle.