### PR TITLE
Exclude test and cli dependencies from shaded jar deps

### DIFF
--- a/cassandra-unit-shaded/pom.xml
+++ b/cassandra-unit-shaded/pom.xml
@@ -133,6 +133,30 @@
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-library</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>org.hamcrest</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant-launcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-cli</groupId>
+                    <artifactId>commons-cli</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>de.jflex</groupId>
+                    <artifactId>jflex</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Because of the shading process, test dependencies get promoted to
compile scope.
Moreover, dependencies used by cassandra for the cli are useless in the
contect of cassandra-unit.