### PR TITLE
Disable metrics. This fixes #255.

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -159,6 +159,7 @@ public class EmbeddedCassandraServerHelper {
                 .withPort(EmbeddedCassandraServerHelper.getNativeTransportPort())
                 .withQueryOptions(queryOptions)
                 .withoutMetrics()
+                .withoutJMXReporting()
                 .build();
 
             session = cluster.connect();

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -158,6 +158,7 @@ public class EmbeddedCassandraServerHelper {
                 .addContactPoints(EmbeddedCassandraServerHelper.getHost())
                 .withPort(EmbeddedCassandraServerHelper.getNativeTransportPort())
                 .withQueryOptions(queryOptions)
+                .withoutMetrics()
                 .build();
 
             session = cluster.connect();


### PR DESCRIPTION
It doesn't make sense to collect metrics and report to JMX while in a unit test.
Furthermore, it doesn't work if your project depends on dropwizard metrics 4.x (see #255).