### PR TITLE
Add function: Set tmpdir using EmbeddedCassandra annotation

### DIFF
--- a/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
+++ b/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/AbstractCassandraUnitTestExecutionListener.java
@@ -34,8 +34,9 @@ public abstract class AbstractCassandraUnitTestExecutionListener extends Abstrac
                 "CassandraUnitTestExecutionListener must be used with @EmbeddedCassandra on " + testContext.getTestClass());
         if (!initialized) {
             String yamlFile = Optional.ofNullable(embeddedCassandra.configuration()).get();
+            String tmpDir = embeddedCassandra.tmpDir();
             long timeout = embeddedCassandra.timeout();
-            EmbeddedCassandraServerHelper.startEmbeddedCassandra(yamlFile, timeout);
+            EmbeddedCassandraServerHelper.startEmbeddedCassandra(yamlFile, tmpDir, timeout);
             initialized = true;
         }
 

--- a/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/EmbeddedCassandra.java
+++ b/cassandra-unit-spring/src/main/java/org/cassandraunit/spring/EmbeddedCassandra.java
@@ -21,5 +21,6 @@ import java.lang.annotation.Target;
 public @interface EmbeddedCassandra {
   // cassandra configuration file
   String configuration() default EmbeddedCassandraServerHelper.DEFAULT_CASSANDRA_YML_FILE;
+  String tmpDir() default EmbeddedCassandraServerHelper.DEFAULT_TMP_DIR;
   long timeout() default EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT;
 }


### PR DESCRIPTION
Hi, I added function that set tmp directory using EmbeddedCassandra annotation.

The default setting create tmp directory under `target/embeddedCassandra` directory.
However,  It can not be changed using EmbeddedCassandra annotation.
If I used Gradle, I'm happy that tmp directory will be created under `build/embeddedCassandra` directory.
So, I added this function.

Please check this pull request.
Thank you.