### PR TITLE
Added function to set tmp directory from CassandraUnitCommandLineStar

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineStarter.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineStarter.java
@@ -59,6 +59,7 @@ public class CassandraUnitCommandLineStarter {
         String schemaOption = commandLine.getOptionValue("s");
         String installationFolder = commandLine.getOptionValue("d");
         String timeout = commandLine.getOptionValue("t");
+        String tmpDir = installationFolder + "/temp";
 
         if (!hasValidValue(timeout)) {
             timeout = "20000";
@@ -68,14 +69,14 @@ public class CassandraUnitCommandLineStarter {
         try (Stream<String> input = Files.lines(cassandraYamlPath);
              PrintWriter output = new PrintWriter(new File(installationFolder, CASSANDRA_YAML), "UTF-8")) {
             input.map(line -> line.replace("9042", port))
-                    .map(line -> line.replace("temp/", installationFolder + "/temp/"))
+                    .map(line -> line.replace("temp/", tmpDir + "/"))
                     .forEachOrdered(output::println);
         } catch (IOException e) {
             e.printStackTrace();
         }
 
         try {
-            EmbeddedCassandraServerHelper.startEmbeddedCassandra(new File(installationFolder, CASSANDRA_YAML), "temp", Long.parseLong(timeout));
+            EmbeddedCassandraServerHelper.startEmbeddedCassandra(new File(installationFolder, CASSANDRA_YAML), tmpDir, Long.parseLong(timeout));
             if (hasValidValue(schemaOption)) {
                 String[] schemas = schemaOption.split(",");
                 for (String schema : schemas) {


### PR DESCRIPTION
Hi, I added function to set tmp directory from CassandraUnitCommandLineStar.

The default setting create tmp directory(`./temp`) under project root directory.
However, It can not be changed using command line option.
I want to change tmp directory from `./temp` to other. (ex: `target/temp` etc...)
So, I added this function.

Please check this pull request.
Thank you.