### PR TITLE
Fixed bug in computing pathname of copied .yaml file

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -17,6 +17,7 @@ import org.yaml.snakeyaml.reader.UnicodeReader;
 import java.io.*;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,8 +97,7 @@ public class EmbeddedCassandraServerHelper {
         }
 
         rmdir(tmpDir);
-        copy(yamlFile, tmpDir);
-        File file = new File(tmpDir + yamlFile);
+        File file = copy(yamlFile, tmpDir).toFile();
         readAndAdaptYaml(file);
         startEmbeddedCassandra(file, tmpDir, timeout);
     }
@@ -285,11 +285,13 @@ public class EmbeddedCassandraServerHelper {
      * @param directory
      * @throws IOException
      */
-    private static void copy(String resource, String directory) throws IOException {
+    private static Path copy(String resource, String directory) throws IOException {
         mkdir(directory);
         String fileName = resource.substring(resource.lastIndexOf("/") + 1);
         InputStream from = EmbeddedCassandraServerHelper.class.getResourceAsStream(resource);
-        Files.copy(from, Paths.get(directory + System.getProperty("file.separator") + fileName));
+        Path copyName = Paths.get(directory, fileName);
+        Files.copy(from, copyName);
+        return copyName;
     }
 
     /**


### PR DESCRIPTION
This PR contains a code fix for issue [#262, Bug in path manipulation: Breaks for .yaml resource file in package other than root package](https://github.com/jsevellec/cassandra-unit/issues/262).

(I don't know if you want to favor using `Path` or favor using `File`.

Also, I don't have time right now to determine how to unit test this change.  Hopefully you can take care of that part. (I've verified it locally in code using `cassandra-unit`.))