### PR TITLE
Disable JMX reporting for datastax client

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineLoader.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineLoader.java
@@ -76,6 +76,7 @@ public class CassandraUnitCommandLineLoader {
 
         Cluster cluster = com.datastax.driver.core.Cluster.builder()
                 .addContactPoints(host)
+                .withoutJMXReporting()
                 .withPort(Integer.parseInt(port))
                 .build();
 

--- a/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineStarter.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/cli/CassandraUnitCommandLineStarter.java
@@ -90,6 +90,7 @@ public class CassandraUnitCommandLineStarter {
     private static void dataSetLoad(String host, String port, String file) {
         Cluster cluster = Cluster.builder()
                 .addContactPoints(host)
+                .withoutJMXReporting()
                 .withPort(Integer.parseInt(port))
                 .build();
         CQLDataLoader dataLoader = new CQLDataLoader(cluster.connect());

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -157,6 +157,7 @@ public class EmbeddedCassandraServerHelper {
             cluster = com.datastax.driver.core.Cluster.builder()
                 .addContactPoints(EmbeddedCassandraServerHelper.getHost())
                 .withPort(EmbeddedCassandraServerHelper.getNativeTransportPort())
+                .withoutJMXReporting()
                 .withQueryOptions(queryOptions)
                 .build();
 


### PR DESCRIPTION
@jsevellec 

This avoids dependency conflicts with newer versions of Dropwizard metrics.  In 4.x, the `JmxReporter` package name changed from `com.codahale.metrics` to `com.codahale.metrics.jmx`.  The datastax driver relies on Dropwizard 3.x so if jmx reporting is enabled, it will try to create an instance of the reporter and a `NoClassDefFoundError` will be thrown.

This PR disables the jmx configuration.  Theres really no need to have the client push metrics to JMX for test cases any way.