### PR TITLE
Added withoutJMXReporting to EmbeddedCassandraServerHelper

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -219,6 +219,7 @@ public class EmbeddedCassandraServerHelper {
             cluster = com.datastax.driver.core.Cluster.builder()
                     .addContactPoints(EmbeddedCassandraServerHelper.getHost())
                     .withPort(EmbeddedCassandraServerHelper.getNativeTransportPort())
+                    .withoutJMXReporting()
                     .withQueryOptions(queryOptions)
                     .build();
         }


### PR DESCRIPTION
Without it, it'll fail for any application that added Dropwizard Metrics 4 dependency:
https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/#metrics-4-compatibility