### PR TITLE
Significantly speed up all schema changes

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -214,6 +214,7 @@ public class EmbeddedCassandraServerHelper {
         if (session == null) {
             DriverConfigLoader configLoader = DriverConfigLoader.programmaticBuilder()
                     .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(0))
+                    .withInt(DefaultDriverOption.METADATA_SCHEMA_MAX_EVENTS, 1)
                     .build();
             session = CqlSession.builder()
                     .addContactPoint(new InetSocketAddress(EmbeddedCassandraServerHelper.getHost(), EmbeddedCassandraServerHelper.getNativeTransportPort()))


### PR DESCRIPTION
Cassandra drivers tend to wait for the schema to settle across all nodes
whenever we execute DDL statements like CREATE/ALTER/DROP. On a single
node cluster we know that the schema settled by the time the query
finished executing. We can thus disable some of the waiting that happens
after every DDL statement, by telling the Datastax driver to not
"debounce" the events.

This reduces the total time for tests to run by about two thirds.