### PR TITLE
Update Cassandra version to 3.11.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <cu.junit.version>4.12</cu.junit.version>
         <cu.logback.version>1.2.3</cu.logback.version>
-        <cu.cassandra.all.version>3.11.5</cu.cassandra.all.version>
+        <cu.cassandra.all.version>3.11.6</cu.cassandra.all.version>
         <cu.cassandra.driver.version>4.3.1</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>


### PR DESCRIPTION
Due to an error on Windows system while starting Cassandra version 3.11.5 I've updated the dependency to 3.11.6. With this version the error is solved and Cassandra can be used again on Windows systems. I've tested the update with a local cassandra-unit build, everything went fine. The error with version 3.11.5 is described here: https://issues.apache.org/jira/browse/CASSANDRA-15426

Could you please merge the pull request and create a new maven artefact in maven central?

Best regards,
Mathias