### PR TITLE
update to cassandra 4

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -59,10 +59,13 @@ public class EmbeddedCassandraServerHelper {
     private static final String INTERNAL_CASSANDRA_DISTRIBUTED_KEYSPACE = "system_distributed";
     private static final String INTERNAL_CASSANDRA_SCHEMA_KEYSPACE = "system_schema";
     private static final String INTERNAL_CASSANDRA_TRACES_KEYSPACE = "system_traces";
+    private static final String INTERNAL_CASSANDRA_VIEWS_KEYSPACE = "system_views";
+    private static final String INTERNAL_CASSANDRA_VIRTUAL_SCHEMA_KEYSPACE = "system_virtual_schema";
 
     private static final Set<String> systemKeyspaces = new HashSet<>(Arrays.asList(INTERNAL_CASSANDRA_KEYSPACE,
             INTERNAL_CASSANDRA_AUTH_KEYSPACE, INTERNAL_CASSANDRA_DISTRIBUTED_KEYSPACE,
-            INTERNAL_CASSANDRA_SCHEMA_KEYSPACE, INTERNAL_CASSANDRA_TRACES_KEYSPACE));
+            INTERNAL_CASSANDRA_SCHEMA_KEYSPACE, INTERNAL_CASSANDRA_TRACES_KEYSPACE,
+            INTERNAL_CASSANDRA_VIEWS_KEYSPACE, INTERNAL_CASSANDRA_VIRTUAL_SCHEMA_KEYSPACE));
 
     public static Predicate<String> nonSystemKeyspaces() {
         return keyspace -> !systemKeyspaces.contains(keyspace);
@@ -240,15 +243,6 @@ public class EmbeddedCassandraServerHelper {
      */
     public static String getHost() {
         return DatabaseDescriptor.getRpcAddress().getHostName();
-    }
-    
-    /**
-     * Get embedded cassandra RPC port.
-     *
-     * @return the cassandra RPC port
-     */
-    public static int getRpcPort() {
-        return DatabaseDescriptor.getRpcPort();
     }
 
     /**

--- a/cassandra-unit/src/main/resources/cu-cassandra.yaml
+++ b/cassandra-unit/src/main/resources/cu-cassandra.yaml
@@ -272,9 +272,6 @@ start_native_transport: true
 # port for the CQL native transport to listen for clients on
 native_transport_port: 9142
 
-# Whether to start the thrift rpc server.
-start_rpc: true
-
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
 # broadcast_address: 1.2.3.4
@@ -286,58 +283,9 @@ start_rpc: true
 # Leaving this blank has the same effect it does for ListenAddress,
 # (i.e. it will be based on the configured hostname of the node).
 rpc_address: localhost
-# port for Thrift to listen for clients on
-rpc_port: 9171
 
 # enable or disable keepalive on rpc connections
 rpc_keepalive: true
-
-# Cassandra provides three options for the RPC Server:
-#
-# sync  -> One connection per thread in the rpc pool (see below).
-#          For a very large number of clients, memory will be your limiting
-#          factor; on a 64 bit JVM, 128KB is the minimum stack size per thread.
-#          Connection pooling is very, very strongly recommended.
-#
-# async -> Nonblocking server implementation with one thread to serve
-#          rpc connections.  This is not recommended for high throughput use
-#          cases. Async has been tested to be about 50% slower than sync
-#          or hsha and is deprecated: it will be removed in the next major release.
-#
-# hsha  -> Stands for "half synchronous, half asynchronous." The rpc thread pool
-#          (see below) is used to manage requests, but the threads are multiplexed
-#          across the different clients.
-#
-# The default is sync because on Windows hsha is about 30% slower.  On Linux,
-# sync/hsha performance is about the same, with hsha of course using less memory.
-rpc_server_type: sync
-
-# Uncomment rpc_min|max|thread to set request pool size.
-# You would primarily set max for the sync server to safeguard against
-# misbehaved clients; if you do hit the max, Cassandra will block until one
-# disconnects before accepting more.  The defaults for sync are min of 16 and max
-# unlimited.
-#
-# For the Hsha server, the min and max both default to quadruple the number of
-# CPU cores.
-#
-# This configuration is ignored by the async server.
-#
-# rpc_min_threads: 16
-# rpc_max_threads: 2048
-
-# uncomment to set socket buffer sizes on rpc connections
-# rpc_send_buff_size_in_bytes:
-# rpc_recv_buff_size_in_bytes:
-
-# Frame size for thrift (maximum field length).
-# 0 disables TFramedTransport in favor of TSocket. This option
-# is deprecated; we strongly recommend using Framed mode.
-thrift_framed_transport_size_in_mb: 15
-
-# The max length of a thrift message, including all fields and
-# internal thrift overhead.
-thrift_max_message_length_in_mb: 16
 
 # Set to true to have Cassandra create a hard link to each sstable
 # flushed or streamed locally in a backups/ subdirectory of the
@@ -511,19 +459,6 @@ dynamic_snitch_reset_interval_in_ms: 600000
 # until the pinned host was 20% worse than the fastest.
 dynamic_snitch_badness_threshold: 0.1
 
-# request_scheduler -- Set this to a class that implements
-# RequestScheduler, which will schedule incoming client requests
-# according to the specific policy. This is useful for multi-tenancy
-# with a single Cassandra cluster.
-# NOTE: This is specifically for requests from the client and does
-# not affect inter node communication.
-# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
-# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
-# client requests to a node with a separate queue for each
-# request_scheduler_id. The scheduler is further customized by
-# request_scheduler_options as described below.
-request_scheduler: org.apache.cassandra.scheduler.NoScheduler
-
 # Scheduler Options vary based on the type of scheduler
 # NoScheduler - Has no options
 # RoundRobin
@@ -550,41 +485,3 @@ request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 # request_scheduler_id -- An identifer based on which to perform
 # the request scheduling. Currently the only valid option is keyspace.
 # request_scheduler_id: keyspace
-
-# index_interval controls the sampling of entries from the primrary
-# row index in terms of space versus time.  The larger the interval,
-# the smaller and less effective the sampling will be.  In technicial
-# terms, the interval coresponds to the number of index entries that
-# are skipped between taking each sample.  All the sampled entries
-# must fit in memory.  Generally, a value between 128 and 512 here
-# coupled with a large key cache size on CFs results in the best trade
-# offs.  This value is not often changed, however if you have many
-# very small rows (many to an OS page), then increasing this will
-# often lower memory usage without a impact on performance.
-index_interval: 128
-
-# Enable or disable inter-node encryption
-# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
-# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
-# suite for authentication, key exchange and encryption of the actual data transfers.
-# NOTE: No custom encryption options are enabled at the moment
-# The available internode options are : all, none, dc, rack
-#
-# If set to dc cassandra will encrypt the traffic between the DCs
-# If set to rack cassandra will encrypt the traffic between the racks
-#
-# The passwords used in these options must match the passwords used when generating
-# the keystore and truststore.  For instructions on generating these files, see:
-# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
-#
-encryption_options:
-    internode_encryption: none
-    keystore: conf/.keystore
-    keystore_password: cassandra
-    truststore: conf/.truststore
-    truststore_password: cassandra
-    # More advanced defaults below:
-    # protocol: TLS
-    # algorithm: SunX509
-    # store_type: JKS
-    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <cu.junit.version>4.12</cu.junit.version>
         <cu.logback.version>1.2.3</cu.logback.version>
-        <cu.cassandra.all.version>3.11.5</cu.cassandra.all.version>
+        <cu.cassandra.all.version>4.0-rc1</cu.cassandra.all.version>
         <cu.cassandra.driver.version>4.3.1</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>
@@ -75,8 +75,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -100,13 +100,6 @@
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>2.4.3</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.7.2</version>
-                <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
@@ -133,6 +126,65 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>surefire-java8</id>
+            <activation>
+                <property>
+                    <name>jdk.version</name>
+                    <value>1.8</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.7.2</version>
+                        <configuration>
+                            <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>surefire-java11</id>
+            <activation>
+                <property>
+                    <name>jdk.version</name>
+                    <value>11</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.7.2</version>
+                        <configuration>
+                            <argLine>-Dfile.encoding=${project.build.sourceEncoding}
+                                -Djdk.attach.allowAttachSelf=true
+                                --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                                --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                                --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED
+                                --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED
+                                --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED
+                                --add-exports java.sql/java.sql=ALL-UNNAMED
+
+                                --add-opens java.base/java.lang.module=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.math=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.module=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
+                                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
update to cassandra 4 (#315) (#294) (#321)

This commit depends on cassandra 4 rc1 which should be updated when the final release comes out
These changes are verified against java 8 AND 11, but in order to run the tests, you must specify -Djdk.version=1.8 or -Djdk.version=11 depending on which version of java your maven is executing with
Users of cassandra-unit will need to provide additional jvm args to their test runtime if they are running on java 11 as specified on pom.xml#165. this is due to a requirement of cassandra 4 (see https://github.com/apache/cassandra/blob/trunk/conf/jvm11-server.options#L59 for the default start script for cassandra4 on jvm11)