### PR TITLE
Cassandra 4.x Support + JUnit 5 Extension + Dependency Upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 WELCOME to CassandraUnit
+*Note that this project was forked from [jsevellec](https://github.com/jsevellec/cassandra-unit) and cassandra 4.x modifications made by [wakingrufus](https://github.com/wakingrufus/cassandra-unit)*
 ========================
 
 Everything is in the wiki : 
-https://github.com/jsevellec/cassandra-unit/wiki
+TODO: A new, updated wiki will be created to address modifications made to the original library.
 
 What is it?
 -----------
@@ -21,14 +22,20 @@ Main features :
 Where to start :
 ----------------
 You can start by reading the wiki : 
-https://github.com/jsevellec/cassandra-unit/wiki
+TODO: A new, updated wiki will be created to address modifications made to the original library.
 
-and you can watch cassandra-unit-examples project.
-https://github.com/jsevellec/cassandra-unit-examples
+Why fork the project? :
+----------------
+The purpose of the forking of this library is to address the following concerns:
+* Last modification of cassandraunit (originally provided by jsevellec) was made in early 2020 and does not seem to be continually maintained
+* Pull requests have been submitted against the original repository, but none have been merged by original contributors since early 2020
+* cassandra 3.x can only be ran on Java 8, making it difficult for organizations moving to Java 11 or higher to upgrade their applications
+* cassandra 4.x is not available, but requires additional work to run (cassandra 4.x work done by wakingrufus)
 
-Mailing List :
---------------
-cassandra-unit-users@googlegroups.com (http://groups.google.com/group/cassandra-unit-users)
+Alternatives to this library :
+----------------
+* [Testcontainers](https://www.testcontainers.org/modules/databases/cassandra/) - For applications and organizations that run on containers (e.g. Docker), Testcontainers is the best choice for spinning up and down new Cassandra instances
+* [Embedded cassandra by nosan](https://github.com/nosan/embedded-cassandra) embedded cassandra approach that allows users to have fine grained control over starting and stopping instances of Cassandra including the version, where and how the files are stored, etc. Note that this dependency does not contain Cassandra dependencies, but instead, downloads Cassandra binaries from Apache and runs that instead.
 
 License :
 ---------

--- a/README.md
+++ b/README.md
@@ -23,18 +23,119 @@ Where to start :
 ----------------
 You can start by reading the wiki : https://github.com/jsevellec/cassandra-unit/wiki
 
-Why fork the project? :
-----------------
-The purpose of the forking of this library is to address the following concerns:
-* Last modification of cassandraunit (originally provided by jsevellec) was made in early 2020 and does not seem to be continually maintained
-* Pull requests have been submitted against the original repository, but none have been merged by original contributors since early 2020
-* cassandra 3.x can only be ran on Java 8, making it difficult for organizations moving to Java 11 or higher to upgrade their applications
-* cassandra 4.x is not available, but requires additional work to run (cassandra 4.x work done by wakingrufus)
-
 Alternatives to this library :
 ----------------
 * [Testcontainers](https://www.testcontainers.org/modules/databases/cassandra/) - For applications and organizations that run on containers (e.g. Docker), Testcontainers is the best choice for spinning up and down new Cassandra instances
 * [Embedded cassandra by nosan](https://github.com/nosan/embedded-cassandra) embedded cassandra approach that allows users to have fine grained control over starting and stopping instances of Cassandra including the version, where and how the files are stored, etc. Note that this dependency does not contain Cassandra dependencies, but instead, downloads Cassandra binaries from Apache and runs that instead.
+
+Modifications made in this fork :
+----------------
+* Cassandra 4.0.0 support
+CassandraUnit now runs on Cassandra 4.0.0, which works on both Java 8 and Java 11. 
+
+***Special Note for Java 11 Support:***
+
+Due to the way that Cassandra 4.0.0 uses unsafe classes and the introduction of the Java Module System in Java 9, in order to run on Java 11, the following jvm options need to be included when running CassandraUnit:
+
+```text
+-Djdk.attach.allowAttachSelf=true
+--add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+--add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+--add-exports java.base/sun.nio.ch=ALL-UNNAMED
+--add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED
+--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED
+--add-exports java.rmi/sun.rmi.server=ALL-UNNAMED
+--add-exports java.sql/java.sql=ALL-UNNAMED
+
+--add-opens java.base/java.lang.module=ALL-UNNAMED
+--add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+--add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+--add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
+--add-opens java.base/jdk.internal.math=ALL-UNNAMED
+--add-opens java.base/jdk.internal.module=ALL-UNNAMED
+--add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
+--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+```
+
+
+For example, to include these options during a Maven build, add the following to the `maven-surefire-plugin` (or `maven-failsafe-plugin` if CassandraUnit is being ran using that plugin):
+```xml
+<build>
+  <plugins>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.7.2</version>
+          <configuration>
+              <argLine>-Dfile.encoding=${project.build.sourceEncoding}
+                  -Djdk.attach.allowAttachSelf=true
+                  --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                  --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                  --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                  --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED
+                  --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED
+                  --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED
+                  --add-exports java.sql/java.sql=ALL-UNNAMED
+
+                  --add-opens java.base/java.lang.module=ALL-UNNAMED
+                  --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+                  --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+                  --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
+                  --add-opens java.base/jdk.internal.math=ALL-UNNAMED
+                  --add-opens java.base/jdk.internal.module=ALL-UNNAMED
+                  --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
+                  --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED</argLine>
+          </configuration>
+      </plugin>
+  </plugins>
+</build>
+```
+
+* Dependencies upgrades
+  - libthrift 0.14.2
+  - Junit Jupiter 5.7.1
+  - Junit Vintage 5.7.1
+  - JNA 5.8.0
+  - Mockito 3.11.2
+  - Cassandra Driver 4.11.0
+  - Spring Core 5.3.9
+ 
+* JUnit 5 Extension for CassandraUnit
+CassandraUnit now provides a JUnit 5 Extension to simplify the use of Cassandra in JUnit 5 test classes.
+
+You can see an example here using the @RegisterExtension annotation (recommended) or use the @ExtendWith annotation: 
+
+```java
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CQLExtensionDataLoadTestWithReadTimeout {
+
+	private static final int READ_TIMEOUT_VALUE = 15000;
+
+	@RegisterExtension
+	static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/simple.cql",
+			"mykeyspace"), READ_TIMEOUT_VALUE);
+
+	@Test
+	void testCQLDataAreInPlace() {
+		test();
+	}
+
+	private void test() {
+		ResultSet result = cqlUnitExtension.getSession()
+				.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+		String val = result.iterator().next().getString("value");
+		assertEquals("Cql loaded string", val);
+	}
+}
+```
+
 
 License :
 ---------

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ WELCOME to CassandraUnit
 
 *Note that this project was forked from [jsevellec](https://github.com/jsevellec/cassandra-unit) and cassandra 4.x modifications made by [wakingrufus](https://github.com/wakingrufus/cassandra-unit)*
 
-Everything is in the wiki : 
-TODO: A new, updated wiki will be created to address modifications made to the original library.
+Everything is in the wiki : https://github.com/jsevellec/cassandra-unit/wiki
 
 What is it?
 -----------
@@ -22,8 +21,7 @@ Main features :
 
 Where to start :
 ----------------
-You can start by reading the wiki : 
-TODO: A new, updated wiki will be created to address modifications made to the original library.
+You can start by reading the wiki : https://github.com/jsevellec/cassandra-unit/wiki
 
 Why fork the project? :
 ----------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 WELCOME to CassandraUnit
-*Note that this project was forked from [jsevellec](https://github.com/jsevellec/cassandra-unit) and cassandra 4.x modifications made by [wakingrufus](https://github.com/wakingrufus/cassandra-unit)*
 ========================
+
+*Note that this project was forked from [jsevellec](https://github.com/jsevellec/cassandra-unit) and cassandra 4.x modifications made by [wakingrufus](https://github.com/wakingrufus/cassandra-unit)*
 
 Everything is in the wiki : 
 TODO: A new, updated wiki will be created to address modifications made to the original library.

--- a/cassandra-unit-shaded/pom.xml
+++ b/cassandra-unit-shaded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.cassandraunit</groupId>
         <artifactId>cassandra-unit-parent</artifactId>
-        <version>4.3.1.1-SNAPSHOT</version>
+        <version>4.4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>cassandra-unit-shaded</artifactId>
     <description>Shaded version of cassandra-unit</description>

--- a/cassandra-unit-spring/pom.xml
+++ b/cassandra-unit-spring/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.cassandraunit</groupId>
 		<artifactId>cassandra-unit-parent</artifactId>
-        <version>4.3.1.1-SNAPSHOT</version>
+        <version>4.4.0.0-SNAPSHOT</version>
 	</parent>
     <groupId>org.cassandraunit</groupId>
 	<artifactId>cassandra-unit-spring</artifactId>

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.cassandraunit</groupId>
         <artifactId>cassandra-unit-parent</artifactId>
-        <version>4.3.1.1-SNAPSHOT</version>
+        <version>4.4.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.cassandraunit</groupId>
     <artifactId>cassandra-unit</artifactId>

--- a/cassandra-unit/pom.xml
+++ b/cassandra-unit/pom.xml
@@ -49,12 +49,21 @@
     </build>
 
     <dependencies>
-
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${cu.junit.version}</version>
-        </dependency> 
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <version>1.7.1</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
@@ -101,12 +110,12 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.12.0</version>
+            <version>0.14.2</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.1.0</version>
+            <version>5.8.0</version>
         </dependency>
 
         <!-- hamcrest could be moved to the test-scope. But as the examples do not declare hamcrest-deps in their pom, 
@@ -133,7 +142,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
+            <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cassandra-unit/src/main/java/org/cassandraunit/jupiter/BaseCassandraUnitExtension.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/jupiter/BaseCassandraUnitExtension.java
@@ -1,0 +1,43 @@
+package org.cassandraunit.jupiter;
+
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * @author Brandon T Johnson
+ */
+public abstract class BaseCassandraUnitExtension implements BeforeAllCallback, AfterAllCallback {
+
+	protected String configurationFileName;
+	protected long startupTimeoutMillis;
+	protected int readTimeoutMillis = 12000;
+
+	public BaseCassandraUnitExtension() {
+		this(EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT);
+	}
+
+	public BaseCassandraUnitExtension(long startupTimeoutMillis) {
+		this.startupTimeoutMillis = startupTimeoutMillis;
+	}
+
+	protected abstract void load();
+
+	@Override
+	public void beforeAll(ExtensionContext extensionContext) throws Exception {
+		/* start an embedded Cassandra */
+		if (configurationFileName != null) {
+			EmbeddedCassandraServerHelper.startEmbeddedCassandra(configurationFileName, startupTimeoutMillis);
+		} else {
+			EmbeddedCassandraServerHelper.startEmbeddedCassandra(startupTimeoutMillis);
+		}
+		/* create structure and load data */
+		load();
+	}
+
+	@Override
+	public void afterAll(ExtensionContext extensionContext) throws Exception {
+		EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+	}
+}

--- a/cassandra-unit/src/main/java/org/cassandraunit/jupiter/CassandraCQLUnitExtension.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/jupiter/CassandraCQLUnitExtension.java
@@ -1,0 +1,68 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import org.cassandraunit.CQLDataLoader;
+import org.cassandraunit.dataset.CQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * @author Brandon T Johnson
+ */
+public class CassandraCQLUnitExtension extends BaseCassandraUnitExtension {
+
+	private final CQLDataSet dataSet;
+	private CqlSession session;
+
+	public CassandraCQLUnitExtension(CQLDataSet dataSet) {
+		this.dataSet = dataSet;
+	}
+
+	public CassandraCQLUnitExtension(CQLDataSet dataSet, int readTimeoutMillis) {
+		this.dataSet = dataSet;
+		this.readTimeoutMillis = readTimeoutMillis;
+	}
+
+	public CassandraCQLUnitExtension(CQLDataSet dataSet, String configurationFileName) {
+		this(dataSet);
+		this.configurationFileName = configurationFileName;
+	}
+
+	public CassandraCQLUnitExtension(CQLDataSet dataSet, String configurationFileName, int readTimeoutMillis) {
+		this(dataSet);
+		this.configurationFileName = configurationFileName;
+		this.readTimeoutMillis = readTimeoutMillis;
+	}
+
+	// The former constructors with hostip and port have been removed. Now host+port is directly read out of the provided
+	// configurationFile(Name). You may also use EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE to select
+	// random (free) ports for EmbeddedCassandra, such that you can start multiple embedded cassandras on the same host
+	// (but not in the same JVM).
+
+	public CassandraCQLUnitExtension(CQLDataSet dataSet, String configurationFileName, long startUpTimeoutMillis) {
+		super(startUpTimeoutMillis);
+		this.dataSet = dataSet;
+		this.configurationFileName = configurationFileName;
+	}
+
+	public CassandraCQLUnitExtension(CQLDataSet dataSet, String configurationFileName, long startUpTimeoutMillis, int readTimeoutMillis) {
+		super(startUpTimeoutMillis);
+		this.dataSet = dataSet;
+		this.configurationFileName = configurationFileName;
+		this.readTimeoutMillis = readTimeoutMillis;
+	}
+
+	@Override
+	protected void load() {
+		session = EmbeddedCassandraServerHelper.getSession();
+		CQLDataLoader dataLoader = new CQLDataLoader(session);
+		dataLoader.load(dataSet);
+		session = dataLoader.getSession();
+	}
+
+	public CqlSession getSession() {
+		return session;
+	}
+}

--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -59,10 +59,13 @@ public class EmbeddedCassandraServerHelper {
     private static final String INTERNAL_CASSANDRA_DISTRIBUTED_KEYSPACE = "system_distributed";
     private static final String INTERNAL_CASSANDRA_SCHEMA_KEYSPACE = "system_schema";
     private static final String INTERNAL_CASSANDRA_TRACES_KEYSPACE = "system_traces";
+    private static final String INTERNAL_CASSANDRA_VIEWS_KEYSPACE = "system_views";
+    private static final String INTERNAL_CASSANDRA_VIRTUAL_SCHEMA_KEYSPACE = "system_virtual_schema";
 
     private static final Set<String> systemKeyspaces = new HashSet<>(Arrays.asList(INTERNAL_CASSANDRA_KEYSPACE,
             INTERNAL_CASSANDRA_AUTH_KEYSPACE, INTERNAL_CASSANDRA_DISTRIBUTED_KEYSPACE,
-            INTERNAL_CASSANDRA_SCHEMA_KEYSPACE, INTERNAL_CASSANDRA_TRACES_KEYSPACE));
+            INTERNAL_CASSANDRA_SCHEMA_KEYSPACE, INTERNAL_CASSANDRA_TRACES_KEYSPACE,
+            INTERNAL_CASSANDRA_VIEWS_KEYSPACE, INTERNAL_CASSANDRA_VIRTUAL_SCHEMA_KEYSPACE));
 
     public static Predicate<String> nonSystemKeyspaces() {
         return keyspace -> !systemKeyspaces.contains(keyspace);
@@ -240,15 +243,6 @@ public class EmbeddedCassandraServerHelper {
      */
     public static String getHost() {
         return DatabaseDescriptor.getRpcAddress().getHostName();
-    }
-    
-    /**
-     * Get embedded cassandra RPC port.
-     *
-     * @return the cassandra RPC port
-     */
-    public static int getRpcPort() {
-        return DatabaseDescriptor.getRpcPort();
     }
 
     /**

--- a/cassandra-unit/src/main/resources/cu-cassandra.yaml
+++ b/cassandra-unit/src/main/resources/cu-cassandra.yaml
@@ -272,9 +272,6 @@ start_native_transport: true
 # port for the CQL native transport to listen for clients on
 native_transport_port: 9142
 
-# Whether to start the thrift rpc server.
-start_rpc: true
-
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
 # broadcast_address: 1.2.3.4
@@ -286,58 +283,9 @@ start_rpc: true
 # Leaving this blank has the same effect it does for ListenAddress,
 # (i.e. it will be based on the configured hostname of the node).
 rpc_address: localhost
-# port for Thrift to listen for clients on
-rpc_port: 9171
 
 # enable or disable keepalive on rpc connections
 rpc_keepalive: true
-
-# Cassandra provides three options for the RPC Server:
-#
-# sync  -> One connection per thread in the rpc pool (see below).
-#          For a very large number of clients, memory will be your limiting
-#          factor; on a 64 bit JVM, 128KB is the minimum stack size per thread.
-#          Connection pooling is very, very strongly recommended.
-#
-# async -> Nonblocking server implementation with one thread to serve
-#          rpc connections.  This is not recommended for high throughput use
-#          cases. Async has been tested to be about 50% slower than sync
-#          or hsha and is deprecated: it will be removed in the next major release.
-#
-# hsha  -> Stands for "half synchronous, half asynchronous." The rpc thread pool
-#          (see below) is used to manage requests, but the threads are multiplexed
-#          across the different clients.
-#
-# The default is sync because on Windows hsha is about 30% slower.  On Linux,
-# sync/hsha performance is about the same, with hsha of course using less memory.
-rpc_server_type: sync
-
-# Uncomment rpc_min|max|thread to set request pool size.
-# You would primarily set max for the sync server to safeguard against
-# misbehaved clients; if you do hit the max, Cassandra will block until one
-# disconnects before accepting more.  The defaults for sync are min of 16 and max
-# unlimited.
-#
-# For the Hsha server, the min and max both default to quadruple the number of
-# CPU cores.
-#
-# This configuration is ignored by the async server.
-#
-# rpc_min_threads: 16
-# rpc_max_threads: 2048
-
-# uncomment to set socket buffer sizes on rpc connections
-# rpc_send_buff_size_in_bytes:
-# rpc_recv_buff_size_in_bytes:
-
-# Frame size for thrift (maximum field length).
-# 0 disables TFramedTransport in favor of TSocket. This option
-# is deprecated; we strongly recommend using Framed mode.
-thrift_framed_transport_size_in_mb: 15
-
-# The max length of a thrift message, including all fields and
-# internal thrift overhead.
-thrift_max_message_length_in_mb: 16
 
 # Set to true to have Cassandra create a hard link to each sstable
 # flushed or streamed locally in a backups/ subdirectory of the
@@ -511,19 +459,6 @@ dynamic_snitch_reset_interval_in_ms: 600000
 # until the pinned host was 20% worse than the fastest.
 dynamic_snitch_badness_threshold: 0.1
 
-# request_scheduler -- Set this to a class that implements
-# RequestScheduler, which will schedule incoming client requests
-# according to the specific policy. This is useful for multi-tenancy
-# with a single Cassandra cluster.
-# NOTE: This is specifically for requests from the client and does
-# not affect inter node communication.
-# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
-# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
-# client requests to a node with a separate queue for each
-# request_scheduler_id. The scheduler is further customized by
-# request_scheduler_options as described below.
-request_scheduler: org.apache.cassandra.scheduler.NoScheduler
-
 # Scheduler Options vary based on the type of scheduler
 # NoScheduler - Has no options
 # RoundRobin
@@ -550,41 +485,3 @@ request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 # request_scheduler_id -- An identifer based on which to perform
 # the request scheduling. Currently the only valid option is keyspace.
 # request_scheduler_id: keyspace
-
-# index_interval controls the sampling of entries from the primrary
-# row index in terms of space versus time.  The larger the interval,
-# the smaller and less effective the sampling will be.  In technicial
-# terms, the interval coresponds to the number of index entries that
-# are skipped between taking each sample.  All the sampled entries
-# must fit in memory.  Generally, a value between 128 and 512 here
-# coupled with a large key cache size on CFs results in the best trade
-# offs.  This value is not often changed, however if you have many
-# very small rows (many to an OS page), then increasing this will
-# often lower memory usage without a impact on performance.
-index_interval: 128
-
-# Enable or disable inter-node encryption
-# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
-# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
-# suite for authentication, key exchange and encryption of the actual data transfers.
-# NOTE: No custom encryption options are enabled at the moment
-# The available internode options are : all, none, dc, rack
-#
-# If set to dc cassandra will encrypt the traffic between the DCs
-# If set to rack cassandra will encrypt the traffic between the racks
-#
-# The passwords used in these options must match the passwords used when generating
-# the keystore and truststore.  For instructions on generating these files, see:
-# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
-#
-encryption_options:
-    internode_encryption: none
-    keystore: conf/.keystore
-    keystore_password: cassandra
-    truststore: conf/.truststore
-    truststore_password: cassandra
-    # More advanced defaults below:
-    # protocol: TLS
-    # algorithm: SunX509
-    # store_type: JKS
-    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLDataLoadTestWithRandomPort.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLDataLoadTestWithRandomPort.java
@@ -1,0 +1,30 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ *
+ * @author Brandon T Johnson
+ *
+ */
+class CQLDataLoadTestWithRandomPort {
+
+    @RegisterExtension
+    static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/simple.cql", "mykeyspace"),
+            EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE);
+
+    @Test
+	void testNativeDriverAccessToRandomPort() {
+        ResultSet result = cqlUnitExtension.getSession()
+                .execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+        String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string",val);
+    }
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithBlankLineEndings.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithBlankLineEndings.java
@@ -1,0 +1,31 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 
+ * @author Brandon T Johnson
+ *
+ */
+class CQLExtensionDataLoadTestWithBlankLineEndings {
+
+    @RegisterExtension
+    static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/statementsWithBlankEndings.cql", "mykeyspace"));
+
+    @Test
+	void testCQLDataAreInPlace() {
+        assertDoesNotThrow(() -> {
+            ResultSet result = cqlUnitExtension.getSession().execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+            String val = result.iterator().next().getString("value");
+            assertEquals("Cql loaded string",val);
+        });
+	}
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithFullOptions.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithFullOptions.java
@@ -1,0 +1,34 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ *
+ * @author Brandon T Johnson
+ *
+ */
+class CQLExtensionDataLoadTestWithFullOptions {
+
+    private static final long STARTUP_TIMEOUT_VALUE = 20000L;
+    private static final int READ_TIMEOUT_VALUE = 17000;
+
+    @RegisterExtension
+    static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/simple.cql",
+            "mykeyspace"), EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE, STARTUP_TIMEOUT_VALUE,
+            READ_TIMEOUT_VALUE);
+
+    @Test
+    void testNativeDriverAccessToRandomPort() {
+        ResultSet result = cqlUnitExtension.getSession()
+                .execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+        String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string", val);
+    }
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithMultiLineCQLStatements.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithMultiLineCQLStatements.java
@@ -1,0 +1,36 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 
+ * @author Brandon T Johnson
+ *
+ */
+class CQLExtensionDataLoadTestWithMultiLineCQLStatements {
+
+    @RegisterExtension
+    static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/multiLineStatements.cql", "mykeyspace"));
+
+    @Test
+	void testCQLDataAreInPlace() {
+        test();
+	}
+
+    @Test
+    void sameTestToMakeSureMultipleTestsAreFine() {
+        test();
+    }
+
+    void test() {
+        ResultSet result = cqlUnitExtension.getSession()
+                .execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+        String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string",val);
+    }
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithNoKeyspaceCreation.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithNoKeyspaceCreation.java
@@ -1,0 +1,38 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 
+ * @author Brandon T Johnson
+ *
+ */
+class CQLExtensionDataLoadTestWithNoKeyspaceCreation {
+
+    @RegisterExtension
+    static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/simpleWithKeyspaceCreation.cql", false, "mykeyspace"));
+    
+    
+    @Test
+	void testCQLDataAreInPlace() {
+        test();
+	}
+
+    @Test
+    void sameTestToMakeSureMultipleTestsAreFine() {
+        test();
+    }
+
+    void test() {
+        ResultSet result = cqlUnitExtension.getSession()
+                .execute("SELECT * FROM testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+        String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string",val);
+    }
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithNoKeyspaceDeletion.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithNoKeyspaceDeletion.java
@@ -1,0 +1,37 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ *
+ * @author Brandon T Johnson
+ *
+ */
+class CQLExtensionDataLoadTestWithNoKeyspaceDeletion {
+
+    @RegisterExtension
+    static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/simple.cql", true, false, "mykeyspace"));
+
+    @Test
+    void testCQLDataAreInPlace() {
+        test();
+    }
+
+    @Test
+    void sameTestToMakeSureMultipleTestsAreFine() {
+        test();
+    }
+
+    void test() {
+        final ResultSet result = cqlUnitExtension.getSession()
+                .execute("SELECT * FROM testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+        final String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string", val);
+    }
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithReadTimeout.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithReadTimeout.java
@@ -1,0 +1,40 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 
+ * @author Brandon T Johnson
+ *
+ */
+class CQLExtensionDataLoadTestWithReadTimeout {
+
+	private static final int READ_TIMEOUT_VALUE = 15000;
+
+	@RegisterExtension
+	static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/simple.cql",
+			"mykeyspace"), READ_TIMEOUT_VALUE);
+
+	@Test
+	void testCQLDataAreInPlace() {
+		test();
+	}
+
+	@Test
+	void sameTestToMakeSureMultipleTestsAreFine() {
+		test();
+	}
+
+	private void test() {
+		ResultSet result = cqlUnitExtension.getSession()
+				.execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+		String val = result.iterator().next().getString("value");
+		assertEquals("Cql loaded string", val);
+	}
+}

--- a/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithRegisterExtension.java
+++ b/cassandra-unit/src/test/java/org/cassandraunit/jupiter/CQLExtensionDataLoadTestWithRegisterExtension.java
@@ -1,0 +1,36 @@
+package org.cassandraunit.jupiter;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 
+ * @author Brandon T Johnson
+ *
+ */
+class CQLExtensionDataLoadTestWithRegisterExtension {
+
+    @RegisterExtension
+    static CassandraCQLUnitExtension cqlUnitExtension = new CassandraCQLUnitExtension(new ClassPathCQLDataSet("cql/simple.cql", "mykeyspace"));
+
+    @Test
+	void testCQLDataAreInPlace() {
+        test();
+	}
+
+    @Test
+    void sameTestToMakeSureMultipleTestsAreFine() {
+        test();
+    }
+
+    private void test() {
+        ResultSet result = cqlUnitExtension.getSession().execute("select * from testCQLTable WHERE id=1690e8da-5bf8-49e8-9583-4dff8a570737");
+
+        String val = result.iterator().next().getString("value");
+        assertEquals("Cql loaded string",val);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <cu.junit.version>4.12</cu.junit.version>
         <cu.logback.version>1.2.3</cu.logback.version>
-        <cu.cassandra.all.version>3.11.5</cu.cassandra.all.version>
+        <cu.cassandra.all.version>4.0-rc1</cu.cassandra.all.version>
         <cu.cassandra.driver.version>4.3.1</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>
@@ -75,8 +75,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -100,13 +100,6 @@
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>2.4.3</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.7.2</version>
-                <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
@@ -133,6 +126,65 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>surefire-java8</id>
+            <activation>
+                <property>
+                    <name>jdk.version</name>
+                    <value>1.8</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.7.2</version>
+                        <configuration>
+                            <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>surefire-java11</id>
+            <activation>
+                <property>
+                    <name>jdk.version</name>
+                    <value>11</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.7.2</version>
+                        <configuration>
+                            <argLine>-Dfile.encoding=${project.build.sourceEncoding}
+                                -Djdk.attach.allowAttachSelf=true
+                                --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                                --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                                --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED
+                                --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED
+                                --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED
+                                --add-exports java.sql/java.sql=ALL-UNNAMED
+
+                                --add-opens java.base/java.lang.module=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.math=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.module=ALL-UNNAMED
+                                --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED
+                                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <packaging>pom</packaging>
     <name>cassandra-unit-parent</name>
     <version>4.4.0.0-SNAPSHOT</version>
-    <description>Test framework to develop with Cassandra</description>
-    <url>https://github.com/jsevellec/cassandra-unit</url>
+    <description>Enhancements for Test framework to develop with Cassandra</description>
+    <url>https://github.com/btjfsu/cassandra-unit</url>
     <licenses>
         <license>
             <name>GNU LESSER GENERAL PUBLIC LICENSE V3.0</name>
@@ -21,10 +21,10 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:https://github.com/jsevellec/cassandra-unit.git</connection>
-        <developerConnection>scm:git:https://github.com/jsevellec/cassandra-unit.git</developerConnection>
-        <url>https://github.com/jsevellec/cassandra-unit.git</url>
-      <tag>cassandra-unit-parent-3.3.0.0</tag>
+        <connection>scm:git:https://github.com/btjfsu/cassandra-unit.git</connection>
+        <developerConnection>scm:git:https://github.com/btjfsu/cassandra-unit.git</developerConnection>
+        <url>https://github.com/btjfsu/cassandra-unit.git</url>
+      <tag>HEAD</tag>
   </scm>
     <modules>
         <module>cassandra-unit</module>
@@ -37,9 +37,9 @@
 
         <cu.junit.version>4.12</cu.junit.version>
         <cu.logback.version>1.2.3</cu.logback.version>
-        <cu.cassandra.all.version>4.0-rc1</cu.cassandra.all.version>
-        <cu.cassandra.driver.version>4.3.1</cu.cassandra.driver.version>
-        <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
+        <cu.cassandra.all.version>4.0.0</cu.cassandra.all.version>
+        <cu.cassandra.driver.version>4.11.0</cu.cassandra.driver.version>
+        <cu.spring.version>5.3.9</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>
     </properties>
 
@@ -75,8 +75,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>cassandra-unit-parent</artifactId>
     <packaging>pom</packaging>
     <name>cassandra-unit-parent</name>
-    <version>4.3.1.1-SNAPSHOT</version>
+    <version>4.4.0.0-SNAPSHOT</version>
     <description>Test framework to develop with Cassandra</description>
     <url>https://github.com/jsevellec/cassandra-unit</url>
     <licenses>


### PR DESCRIPTION
Why fork the project? :
----------------
The purpose of the forking of this library is to address the following concerns:
* Last modification of cassandraunit (originally provided by jsevellec) was made in early 2020 and does not seem to be continually maintained
* Pull requests have been submitted against the original repository, but none have been merged by original contributors since early 2020
* cassandra 3.x can only be ran on Java 8, making it difficult for organizations moving to Java 11 or higher to upgrade their applications
* cassandra 4.x is not available, but requires additional work to run (cassandra 4.x work done by wakingrufus)
* No JUnit 5 extension available for CassandraUnit for services using JUnit 5 testing framework only