### PR TITLE
Check the session's status

### DIFF
--- a/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
+++ b/cassandra-unit/src/main/java/org/cassandraunit/utils/EmbeddedCassandraServerHelper.java
@@ -211,7 +211,7 @@ public class EmbeddedCassandraServerHelper {
     }
 
     private static synchronized void initSession() {
-        if (session == null) {
+        if (session == null || session.isClosed()) {
             DriverConfigLoader configLoader = DriverConfigLoader.programmaticBuilder()
                     .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(0))
                     .withInt(DefaultDriverOption.METADATA_SCHEMA_MAX_EVENTS, 1)


### PR DESCRIPTION
I wanted to integrate the EmbeddedCassandraServer with a migration tool, however this migration management tool would close the sessions that is was provided with. As far as I could see, there are now way to re-establish a connection that was closed inside this project.

This simple fix allow us to call re-create a valid session after the migration by calling `getSession` (which would trigger a new `initSession`). This is however not the perfect fix because a lot of private methods access the `session` field directly  and would still try to used a closed session if the second call to `initSession` is made.

It also seems that some abstract classes such as `AbstractCassandraUnit4CQLTestCase` are storing the first session they receive and would not benefit from an updated call to `getSession` in the underlying `CassandraCQLUnit` object.

What do you think ? 